### PR TITLE
linux: bootstrap fixes for unprivileged Hermes-KMS virtual displays

### DIFF
--- a/cmake/compile_definitions/linux.cmake
+++ b/cmake/compile_definitions/linux.cmake
@@ -18,6 +18,12 @@ if(${SUNSHINE_ENABLE_CUDA})
         set(CUDA_FOUND ON)
         enable_language(CUDA)
 
+        # Distro-packaged CUDA toolkits live in /usr, so dependency include dirs
+        # resolve to /usr/include and CMake passes `-isystem /usr/include` to
+        # nvcc, breaking GCC's include_next chain (cmath -> math.h not found).
+        # Marking it implicit makes CMake drop it from the command line.
+        list(APPEND CMAKE_CUDA_IMPLICIT_INCLUDE_DIRECTORIES "/usr/include")
+
         message(STATUS "CUDA Compiler Version: ${CMAKE_CUDA_COMPILER_VERSION}")
         set(CMAKE_CUDA_ARCHITECTURES "")
 

--- a/src/platform/linux/graphics.cpp
+++ b/src/platform/linux/graphics.cpp
@@ -353,6 +353,17 @@ namespace egl {
         return nullptr;
     }
 
+    // Platform init loads EGL after its capture-source checks, but Hermes can
+    // reach this through the virtual-display bootstrap even when those checks
+    // failed (e.g. KMS capture without CAP_SYS_ADMIN). Load lazily instead of
+    // calling a NULL glad pointer.
+    if (!eglGetPlatformDisplay) {
+      if (!gladLoaderLoadEGL(EGL_NO_DISPLAY) || !eglGetPlatformDisplay) {
+        BOOST_LOG(error) << "Couldn't load EGL library"sv;
+        return nullptr;
+      }
+    }
+
     // native_display.left() equals native_display.right()
     display_t display = eglGetPlatformDisplay(egl_platform, native_display_p, nullptr);
 

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -2099,6 +2099,16 @@ namespace platf {
 
     kms::card_descriptors = std::move(cds);
 
+    // Active Hermes-KMS virtual displays are capturable through their render
+    // node even when no physical framebuffer handle is readable (no DRM
+    // master, no CAP_SYS_ADMIN), so expose them alongside the physical
+    // outputs. Session display lookups match these by name (e.g. HERMES-1).
+    for (auto &name : VDISPLAY::listHermesKmsDisplayNames()) {
+      if (std::find(display_names.begin(), display_names.end(), name) == display_names.end()) {
+        display_names.emplace_back(std::move(name));
+      }
+    }
+
     return display_names;
   }
 

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -996,7 +996,22 @@ std::string get_local_ip_for_gateway() {
   std::shared_ptr<display_t> kms_display(mem_type_e hwdevice_type, const std::string &display_name, const video::config_t &config);
 
   bool verify_kms() {
-    return !kms_display_names(mem_type_e::unknown).empty();
+    if (!kms_display_names(mem_type_e::unknown).empty()) {
+      return true;
+    }
+
+    // Hermes-KMS virtual displays are captured through the driver's render
+    // node (no DRM master, no CAP_SYS_ADMIN), so a present driver makes the
+    // KMS backend usable even when no physical framebuffer handle is
+    // readable. Without this, running unprivileged with capture=kms would
+    // abort platform init before the virtual-display bootstrap can run.
+    if (config::video.virtual_display_backend == "hermes_kms" &&
+        VDISPLAY::isHermesKmsDriverPresent()) {
+      BOOST_LOG(info) << "KMS capture enabled through Hermes-KMS render-node path (no CAP_SYS_ADMIN)"sv;
+      return true;
+    }
+
+    return false;
   }
 #endif
 

--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -3262,6 +3262,26 @@ namespace VDISPLAY {
     return -1;
   }
 
+  bool isHermesKmsDriverPresent() {
+    auto devices = hermes_kms::open_devices(false);
+    const bool present = !devices.empty();
+    for (auto &candidate : devices) {
+      hermes_kms::close_device(candidate);
+    }
+    return present;
+  }
+
+  std::vector<std::string> listHermesKmsDisplayNames() {
+    std::lock_guard<std::mutex> lock(vdisplay_mutex);
+    std::vector<std::string> names;
+    for (const auto &[guid, vdinfo] : virtual_displays) {
+      if (vdinfo.using_hermes_kms) {
+        names.emplace_back(vdinfo.name);
+      }
+    }
+    return names;
+  }
+
   std::string getHermesKmsDevicePath(const std::string &displayName) {
     const int card_index = getHermesKmsCardIndex(displayName);
     return card_index >= 0 ?

--- a/src/platform/linux/virtual_display.h
+++ b/src/platform/linux/virtual_display.h
@@ -315,6 +315,12 @@ namespace VDISPLAY {
   /** Get the DRM card index for a Hermes-KMS display. */
   int getHermesKmsCardIndex(const std::string &displayName);
 
+  /** Check whether a usable Hermes-KMS DRM device exists on this host. */
+  bool isHermesKmsDriverPresent();
+
+  /** List the display names of all registered Hermes-KMS virtual displays. */
+  std::vector<std::string> listHermesKmsDisplayNames();
+
   /** Get the primary DRM node path assigned to a Hermes-KMS display. */
   std::string getHermesKmsDevicePath(const std::string &displayName);
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -309,6 +309,9 @@ namespace proc {
     ~deinit_t() {
       proc.terminate_all_isolated();
       proc.terminate();
+      // Join the watchdog thread before global destructors run, otherwise a
+      // still-joinable std::thread aborts the process on exit.
+      VDISPLAY::closeVDisplayDevice();
     }
   };
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1399,7 +1399,13 @@ namespace proc {
           // empty name when probing graphics cards.
 
           if (virtual_display_ready_for_capture || this->virtual_display) {
-            config::video.output_name = display_device::map_display_name(this->display_name);
+            // map_display_name resolves a device id on Windows but returns an
+            // empty string on platforms without a settings manager (Linux).
+            // Wiping output_name here would make the pre-stream encoder probe
+            // look up an empty display and fail, so keep the virtual display's
+            // own name in that case (e.g. HERMES-1).
+            auto mapped_name = display_device::map_display_name(this->display_name);
+            config::video.output_name = mapped_name.empty() ? this->display_name : std::move(mapped_name);
           }
         } else {
           BOOST_LOG(warning) << "Virtual Display creation failed, or cannot get created display name in time!";


### PR DESCRIPTION
First part of the split requested in the #16 review: the small generic Linux fixes, independent of the NVENC work.

- **process**: keep the virtual display's own name when `map_display_name()` returns an empty string (Linux has no settings manager), so the pre-stream encoder probe does not look up an empty display
- **misc**: let `verify_kms()` pass through the Hermes-KMS render-node path when no physical framebuffer handle is readable (no DRM master, no CAP_SYS_ADMIN)
- **kmsgrab**: list active Hermes-KMS virtual displays in `kms_display_names()` so session display lookups match them by name
- **egl**: load EGL lazily before `eglGetPlatformDisplay()` instead of calling a null glad pointer when platform init skipped the load
- **cmake**: mark `/usr/include` as an implicit CUDA include dir so nvcc's `include_next` chain stays intact with distro-packaged CUDA toolkits (Fedora and friends)

The lazy EGL load and the cmake line are included here rather than in the CUDA PR because they are what makes the unprivileged bootstrap reach EGL at all and what makes any of the split branches compile on distro toolkits.

Tested on Nobara 44 (KDE Wayland, RTX 5060 Ti): builds clean with SUNSHINE_ENABLE_CUDA=ON and the unprivileged Hermes-KMS session still comes up. The mode switching, NVENC CPU-copy and CUDA/EGL parts follow as separate PRs.