### PR TITLE
linux: dynamic per-client mode switching for Hermes-KMS virtual displays

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1575,6 +1575,40 @@ namespace nvhttp {
         return;
       }
     }
+#ifndef _WIN32
+    else if (!isolated_sessions && no_active_sessions && proc::proc.virtual_display && !proc::proc.display_name.empty()) {
+      // A resumed app keeps its virtual display, but every client brings its
+      // own mode: adapt resolution AND refresh to this client's request
+      // before the stream starts, exactly like a fresh launch would.
+      int target_fps = launch_session->fps ? launch_session->fps : 60000;
+      if (target_fps < 1000) {
+        target_fps *= 1000;
+      }
+      if (launch_session->width > 0 && launch_session->height > 0) {
+        const int change_result = VDISPLAY::changeDisplaySettings(
+          proc::proc.display_name.c_str(),
+          launch_session->width,
+          launch_session->height,
+          target_fps
+        );
+        if (change_result != 0) {
+          // Capture re-reads the active scanout geometry on init, so the
+          // encoders below follow the display's real mode, not the request.
+          BOOST_LOG(warning) << "Virtual display did not reach "sv
+                             << launch_session->width << 'x' << launch_session->height
+                             << "; streaming the display's active mode instead."sv;
+        }
+      }
+
+      if (video::probe_encoders()) {
+        tree.put("root.resume", 0);
+        tree.put("root.<xmlattr>.status_code", 503);
+        tree.put("root.<xmlattr>.status_message", "Failed to initialize video capture/encoding. Is a display connected and turned on?");
+
+        return;
+      }
+    }
+#endif
 
     auto encryption_mode = net::encryption_mode_for_address(request->remote_endpoint().address());
     if (!launch_session->rtsp_cipher && encryption_mode == config::ENCRYPTION_MODE_MANDATORY) {

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1585,11 +1585,20 @@ namespace nvhttp {
         target_fps *= 1000;
       }
       if (launch_session->width > 0 && launch_session->height > 0) {
+        // No activateVirtualDisplayOutput() here, unlike the launch path in
+        // process.cpp: reaching this branch requires a running app that still
+        // owns its virtual display (proc.virtual_display), so the output was
+        // activated at launch and is kept alive by the session. Only the mode
+        // may differ for the new client. The deadline is shorter than the
+        // default because this runs synchronously inside the /resume handler
+        // and clients time out on long stalls; on failure the stream simply
+        // keeps the display's active mode.
         const int change_result = VDISPLAY::changeDisplaySettings(
           proc::proc.display_name.c_str(),
           launch_session->width,
           launch_session->height,
-          target_fps
+          target_fps,
+          1500
         );
         if (change_result != 0) {
           // Capture re-reads the active scanout geometry on init, so the

--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -995,6 +995,81 @@ namespace VDISPLAY {
       return result;
     }
 
+    /**
+     * @brief Switch a KScreen output to the exact mode width x height @ refresh_hz.
+     *
+     * The Hermes-KMS driver re-probes its mode list on SET_OUTPUT, but a
+     * compositor keeps the current mode of an already-connected output, so the
+     * client-requested mode has to be applied explicitly. KWin also needs a
+     * moment to process the hotplug re-probe before the new mode shows up in
+     * its list, hence the retry loop with verification.
+     */
+    static bool apply_output_mode(const std::string &connector, int width, int height, int refresh_hz) {
+      if (!available() || !safe_output_name(connector)) {
+        return false;
+      }
+
+      const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(4);
+      bool command_sent = false;
+
+      while (std::chrono::steady_clock::now() < deadline) {
+        const auto json_text = command_output("kscreen-doctor -j");
+        std::string mode_id;
+        std::string current_mode_id;
+
+        if (!json_text.empty()) {
+          try {
+            const auto data = nlohmann::json::parse(json_text);
+            for (const auto &entry : data.value("outputs", nlohmann::json::array())) {
+              if (entry.value("name", std::string {}) != connector) {
+                continue;
+              }
+              current_mode_id = entry.value("currentModeId", std::string {});
+
+              // Pick the listed mode closest in refresh to the request.
+              double best_delta = 1.0;
+              for (const auto &mode : entry.value("modes", nlohmann::json::array())) {
+                const auto size = mode.value("size", nlohmann::json::object());
+                if (size.value("width", 0) != width || size.value("height", 0) != height) {
+                  continue;
+                }
+                const double rate = mode.value("refreshRate", 0.0);
+                const double delta = rate > refresh_hz ? rate - refresh_hz : refresh_hz - rate;
+                if (delta < best_delta) {
+                  best_delta = delta;
+                  mode_id = mode.value("id", std::string {});
+                }
+              }
+              break;
+            }
+          } catch (const std::exception &error) {
+            BOOST_LOG(warning) << "[VDISPLAY/KScreen] Could not parse mode list: " << error.what();
+          }
+        }
+
+        if (!mode_id.empty() &&
+            std::all_of(mode_id.begin(), mode_id.end(), [](unsigned char c) {
+              return std::isalnum(c);
+            })) {
+          if (command_sent && current_mode_id == mode_id) {
+            BOOST_LOG(info) << "[VDISPLAY/KScreen] " << connector << " switched to "
+                            << width << 'x' << height << '@' << refresh_hz << "Hz (mode " << mode_id << ')';
+            return true;
+          }
+
+          std::string command = "kscreen-doctor output." + connector + ".mode." + mode_id;
+          command_output(command.c_str());
+          command_sent = true;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds {150});
+      }
+
+      BOOST_LOG(warning) << "[VDISPLAY/KScreen] " << connector << " did not reach "
+                         << width << 'x' << height << '@' << refresh_hz << "Hz in time.";
+      return false;
+    }
+
     static std::set<std::string> connected_output_names(const std::vector<output_t> &current) {
       std::set<std::string> result;
       for (const auto &output : current) {
@@ -2625,7 +2700,12 @@ namespace VDISPLAY {
     uint32_t fps,
     const uuid_util::uuid_t &guid
   ) {
-    std::lock_guard<std::mutex> lock(vdisplay_mutex);
+    std::unique_lock<std::mutex> lock(vdisplay_mutex);
+
+    // Connector whose compositor mode still has to be applied. The KScreen
+    // apply polls kscreen-doctor for seconds, so it runs after the mutex is
+    // released instead of stalling every other virtual-display operation.
+    std::string pending_mode_connector;
 
     if (driver_status != DRIVER_STATUS::OK) {
       BOOST_LOG(error) << "[VDISPLAY] Driver not initialized.";
@@ -2749,6 +2829,11 @@ namespace VDISPLAY {
             vdinfo.connector_name,
             "Hermes-KMS"
           );
+
+          // Enabling an already-connected output keeps whatever mode the
+          // compositor used last. The client's exact mode is applied through
+          // KScreen once the display mutex is released below.
+          pending_mode_connector = vdinfo.connector_name;
         }
       }
       hermes_kms::close_device(device);
@@ -2837,6 +2922,16 @@ namespace VDISPLAY {
     BOOST_LOG(info) << "[VDISPLAY] Virtual display created successfully: " << display_name;
     BOOST_LOG(info) << "[VDISPLAY] Mode: " << backend_name(backend) << " (real virtual display)";
 
+    lock.unlock();
+
+    if (!pending_mode_connector.empty()) {
+      if (!kscreen::apply_output_mode(pending_mode_connector, static_cast<int>(width), static_cast<int>(height), static_cast<int>(fps_hz))) {
+        BOOST_LOG(warning) << "[VDISPLAY] Compositor did not switch " << pending_mode_connector
+                           << " to " << width << 'x' << height << '@' << fps_hz
+                           << "Hz; capture will use the compositor's active mode.";
+      }
+    }
+
     return display_name;
   }
 
@@ -2878,8 +2973,6 @@ namespace VDISPLAY {
   }
 
   int changeDisplaySettings(const char *deviceName, int width, int height, int refresh_rate) {
-    std::lock_guard<std::mutex> lock(vdisplay_mutex);
-
     refresh_rate = normalize_refresh_rate(refresh_rate);
     const int refresh_hz = refresh_rate / 1000;
 
@@ -2892,9 +2985,19 @@ namespace VDISPLAY {
     BOOST_LOG(info) << "[VDISPLAY] Changing display settings for " << deviceName
                     << " to " << width << "x" << height << "@" << refresh_hz << "Hz";
 
-    // Find the virtual display
-    for (auto &[guid, vdinfo] : virtual_displays) {
-      if (vdinfo.name == deviceName) {
+    // Update the driver-side state under the mutex, but remember the KScreen
+    // work for afterwards: apply_output_mode() polls kscreen-doctor for
+    // seconds and must not stall every other virtual-display operation.
+    std::string kscreen_connector;
+    bool found = false;
+    {
+      std::lock_guard<std::mutex> lock(vdisplay_mutex);
+      for (auto &[guid, vdinfo] : virtual_displays) {
+        if (vdinfo.name != deviceName) {
+          continue;
+        }
+        found = true;
+
         // createVirtualDisplay() is normally followed by this call with the
         // same values. Reconnecting EVDI in that case causes an avoidable
         // compositor modeset and a burst of capture reinitializations.
@@ -2920,14 +3023,34 @@ namespace VDISPLAY {
           if (!hermes_kms::set_output(vdinfo.drm_fd, true, width, height, refresh_hz, vdinfo.session_id)) {
             return -1;
           }
-        }
 
-        BOOST_LOG(info) << "[VDISPLAY] Display settings updated successfully.";
-        return 0;
+          // SET_OUTPUT only updates the driver's mode list; an already
+          // connected output keeps its current compositor mode. The client's
+          // exact mode is applied through KScreen below, outside the lock.
+          if (!config::video.hermes_kms_isolated_sessions && !vdinfo.connector_name.empty()) {
+            kscreen_connector = vdinfo.connector_name;
+          }
+        }
+        break;
       }
     }
 
-    BOOST_LOG(debug) << "[VDISPLAY] Display not found: " << deviceName;
+    if (!found) {
+      // Not an error: the active display may be a physical one that simply
+      // has no virtual-display state to update.
+      BOOST_LOG(debug) << "[VDISPLAY] Display not found: " << deviceName;
+      return 0;
+    }
+
+    if (!kscreen_connector.empty() &&
+        !kscreen::apply_output_mode(kscreen_connector, width, height, refresh_hz)) {
+      BOOST_LOG(warning) << "[VDISPLAY] Compositor did not switch " << kscreen_connector
+                         << " to " << width << 'x' << height << '@' << refresh_hz
+                         << "Hz; the previous compositor mode stays active.";
+      return 1;
+    }
+
+    BOOST_LOG(info) << "[VDISPLAY] Display settings updated successfully.";
     return 0;
   }
 

--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -1003,13 +1003,17 @@ namespace VDISPLAY {
      * client-requested mode has to be applied explicitly. KWin also needs a
      * moment to process the hotplug re-probe before the new mode shows up in
      * its list, hence the retry loop with verification.
+     *
+     * KDE-only by design: on compositors without kscreen-doctor,
+     * available() is false and this returns without doing anything, so the
+     * output keeps whatever mode the compositor chose.
      */
-    static bool apply_output_mode(const std::string &connector, int width, int height, int refresh_hz) {
+    static bool apply_output_mode(const std::string &connector, int width, int height, int refresh_hz, int deadline_ms = 4000) {
       if (!available() || !safe_output_name(connector)) {
         return false;
       }
 
-      const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(4);
+      const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(deadline_ms);
       bool command_sent = false;
 
       while (std::chrono::steady_clock::now() < deadline) {
@@ -2972,7 +2976,7 @@ namespace VDISPLAY {
     return true;
   }
 
-  int changeDisplaySettings(const char *deviceName, int width, int height, int refresh_rate) {
+  int changeDisplaySettings(const char *deviceName, int width, int height, int refresh_rate, int kscreen_deadline_ms) {
     refresh_rate = normalize_refresh_rate(refresh_rate);
     const int refresh_hz = refresh_rate / 1000;
 
@@ -3043,7 +3047,7 @@ namespace VDISPLAY {
     }
 
     if (!kscreen_connector.empty() &&
-        !kscreen::apply_output_mode(kscreen_connector, width, height, refresh_hz)) {
+        !kscreen::apply_output_mode(kscreen_connector, width, height, refresh_hz, kscreen_deadline_ms)) {
       BOOST_LOG(warning) << "[VDISPLAY] Compositor did not switch " << kscreen_connector
                          << " to " << width << 'x' << height << '@' << refresh_hz
                          << "Hz; the previous compositor mode stays active.";

--- a/src/platform/linux/virtual_display.h
+++ b/src/platform/linux/virtual_display.h
@@ -230,7 +230,8 @@ namespace VDISPLAY {
    * @param width The new width.
    * @param height The new height.
    * @param refresh_rate The new refresh rate (in mHz).
-   * @return 0 on success, non-zero on failure.
+   * @return 0 on success, -1 on failure, 1 when the driver accepted the mode
+   *         but the compositor kept the previously active one.
    */
   int changeDisplaySettings(const char *deviceName, int width, int height, int refresh_rate);
 

--- a/src/platform/linux/virtual_display.h
+++ b/src/platform/linux/virtual_display.h
@@ -230,10 +230,13 @@ namespace VDISPLAY {
    * @param width The new width.
    * @param height The new height.
    * @param refresh_rate The new refresh rate (in mHz).
+   * @param kscreen_deadline_ms How long the compositor-side mode apply may
+   *        poll before giving up. Hot paths (e.g. /resume) pass a shorter
+   *        deadline than the default.
    * @return 0 on success, -1 on failure, 1 when the driver accepted the mode
    *         but the compositor kept the previously active one.
    */
-  int changeDisplaySettings(const char *deviceName, int width, int height, int refresh_rate);
+  int changeDisplaySettings(const char *deviceName, int width, int height, int refresh_rate, int kscreen_deadline_ms = 4000);
 
   /**
    * @brief Change the display settings with isolated display option.

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -497,12 +497,14 @@ namespace proc {
       return 503;
     }
 
-    VDISPLAY::changeDisplaySettings(
-      display_name.c_str(),
-      launch_session->width,
-      launch_session->height,
-      target_fps
-    );
+    if (VDISPLAY::changeDisplaySettings(
+          display_name.c_str(),
+          launch_session->width,
+          launch_session->height,
+          target_fps
+        ) != 0) {
+      BOOST_LOG(warning) << "Virtual display did not adopt the requested mode; capture will use the display's active mode.";
+    }
     if (!config::video.hermes_kms_isolated_sessions &&
         !VDISPLAY::activateVirtualDisplayOutput(display_name)) {
       BOOST_LOG(error) << "[VDISPLAY/Hermes-KMS] The compositor did not activate session output "
@@ -1340,10 +1342,14 @@ namespace proc {
           if (launch_session->width && launch_session->height && launch_session->fps) {
             // Apply display settings
 #ifdef _WIN32
-            VDISPLAY::changeDisplaySettings(vdisplayName.c_str(), render_width, render_height, target_fps);
+            const int change_result = VDISPLAY::changeDisplaySettings(vdisplayName.c_str(), render_width, render_height, target_fps);
 #else
-            VDISPLAY::changeDisplaySettings(vdisplayName.c_str(), render_width, render_height, target_fps);
+            const int change_result = VDISPLAY::changeDisplaySettings(vdisplayName.c_str(), render_width, render_height, target_fps);
 #endif
+            if (change_result != 0) {
+              BOOST_LOG(warning) << "Virtual display did not adopt " << render_width << 'x' << render_height
+                                 << "; capture will use the display's active mode.";
+            }
           }
 
 #ifndef _WIN32


### PR DESCRIPTION
Second part of the split requested in the #16 review: the KScreen mode switching, reworked to address the review's mode-switch and locking concerns.

Base behaviour: the Hermes-KMS driver re-probes its mode list on SET_OUTPUT, but a compositor keeps the current mode of an already-connected output, so the client's requested resolution and refresh rate are applied explicitly through kscreen-doctor, and `apply_output_mode()` only reports success after verifying via `currentModeId` that the mode really became active.

Review points addressed:

- **Failure propagation**: `changeDisplaySettings()` now returns 1 when the driver accepted the mode but the compositor kept the previous one, instead of logging a warning and reporting success. The `/resume` path checks the result and logs that the stream will use the display's active mode. Since the capture classes re-read the actual scanout geometry on init, the encoder probe that follows always uses the real active dimensions as the source of truth, not the request.
- **Locking**: the KScreen polling (up to ~4 s of kscreen-doctor calls) no longer runs under `vdisplay_mutex`. `createVirtualDisplay()` and `changeDisplaySettings()` update driver/display state under the lock, release it, and do the compositor work afterwards.
- `changeDisplaySettings()` still returns 0 for an unknown display name on purpose: the active display may be a physical one with no virtual-display state to update, which is a no-op rather than an error. Happy to change that if you prefer a distinct code.

Tested on Nobara 44 (KDE Wayland, RTX 5060 Ti): switching client resolutions between sessions (1440p/1080p and 60/120 Hz) activates the requested mode. The failure-propagation path builds and follows the code paths above, but I have not simulated a failing compositor switch end to end yet.
