### PR TITLE
linux: NVENC support for Hermes-KMS virtual displays via CPU-copy capture

### DIFF
--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -12,6 +12,7 @@
 // platform includes
 #include <drm_fourcc.h>
 #include <linux/dma-buf.h>
+#include <poll.h>
 #include <sys/capability.h>
 #include <sys/mman.h>
 #include <xf86drm.h>
@@ -1860,6 +1861,203 @@ namespace platf {
       uint64_t last_sequence {0};
     };
 
+    // Hermes-KMS capture through a CPU copy of the scanout DMA-BUF.
+    //
+    // The CPU view of the Hermes framebuffer is always pixel-correct, while
+    // NVIDIA's EGL import of these system-memory DMA-BUFs has been observed to
+    // read the wrong pages beyond the first ones (visible as diagonal
+    // stripes). Until that import path is proven reliable, NVENC sessions map
+    // the buffer, de-pad the rows on the CPU and let the regular RAM->CUDA
+    // upload path feed the encoder. Costs one memcpy per frame (~1-2 ms at
+    // 1440p-class sizes); correctness over the last microseconds.
+    class display_hermes_ram_t: public display_t {
+    public:
+      display_hermes_ram_t(mem_type_e mem_type):
+          display_t(mem_type) {
+      }
+
+      ~display_hermes_ram_t() override {
+        if (hermes_fd >= 0) {
+          ::close(hermes_fd);
+          hermes_fd = -1;
+        }
+      }
+
+      int init(const std::string &display_name, const ::video::config_t &config) {
+        BOOST_LOG(info) << "Hermes-KMS CPU-copy capture path selected for ["sv << display_name << ']';
+        delay = std::chrono::nanoseconds {1s} / config.framerate;
+
+        hermes_fd = VDISPLAY::hermesKmsOpenCapture(display_name);
+        if (hermes_fd < 0) {
+          return -1;
+        }
+
+        int w = 0;
+        int h = 0;
+        if (!VDISPLAY::hermesKmsCaptureSize(hermes_fd, w, h) || w <= 0 || h <= 0) {
+          BOOST_LOG(error) << "Hermes-KMS capture: no active scanout geometry yet."sv;
+          return -1;
+        }
+
+        width = img_width = w;
+        height = img_height = h;
+        img_offset_x = 0;
+        img_offset_y = 0;
+        env_width = w;
+        env_height = h;
+
+        BOOST_LOG(info) << "Hermes-KMS CPU-copy capture ready: "sv << w << 'x' << h;
+        return 0;
+      }
+
+      std::shared_ptr<img_t> alloc_img() override {
+        auto img = std::make_shared<kms_img_t>();
+        img->width = width;
+        img->height = height;
+        img->pixel_pitch = 4;
+        img->row_pitch = img->pixel_pitch * width;
+        img->data = new std::uint8_t[height * img->row_pitch];
+
+        return img;
+      }
+
+      int dummy_img(platf::img_t *img) override {
+        return 0;
+      }
+
+      std::unique_ptr<avcodec_encode_device_t> make_avcodec_encode_device(pix_fmt_e pix_fmt) override {
+#ifdef SUNSHINE_BUILD_CUDA
+        if (mem_type == mem_type_e::cuda) {
+          return cuda::make_avcodec_encode_device(width, height, false);
+        }
+#endif
+#ifdef SUNSHINE_BUILD_VAAPI
+        if (mem_type == mem_type_e::vaapi) {
+          return va::make_avcodec_encode_device(width, height, false);
+        }
+#endif
+        return std::make_unique<avcodec_encode_device_t>();
+      }
+
+      capture_e snapshot(const pull_free_image_cb_t &pull_free_image_cb, std::shared_ptr<platf::img_t> &img_out, std::chrono::milliseconds timeout, bool /* cursor */) {
+        VDISPLAY::HermesKmsFrame frame;
+        const auto timeout_ms = static_cast<uint32_t>(std::max<std::chrono::milliseconds::rep>(1, timeout.count()));
+        if (!VDISPLAY::hermesKmsAcquireFrame(hermes_fd, last_sequence, timeout_ms, frame)) {
+          return platf::capture_e::timeout;
+        }
+        accumulate_capture_metric("hermes-kms-cpu", frame.acquire_ns);
+
+        if (frame.width != img_width || frame.height != img_height) {
+          frame.close();
+          return platf::capture_e::reinit;
+        }
+
+        if (!pull_free_image_cb(img_out)) {
+          frame.close();
+          return platf::capture_e::interrupted;
+        }
+
+        // A successful ACQUIRE_FRAME only means the frame was exported, not
+        // that the producer finished writing it. The driver exports the
+        // framebuffer's write fence as a sync file; wait for it before
+        // touching the pixels.
+        if (frame.sync_file_fd >= 0) {
+          pollfd fence_poll {frame.sync_file_fd, POLLIN, 0};
+          int poll_result = 0;
+          do {
+            poll_result = poll(&fence_poll, 1, static_cast<int>(timeout_ms));
+          } while (poll_result < 0 && errno == EINTR);
+          if (poll_result <= 0) {
+            BOOST_LOG(warning) << "Hermes-KMS CPU capture: frame fence did not signal in time."sv;
+            frame.close();
+            return platf::capture_e::timeout;
+          }
+        }
+
+        const size_t row_bytes = (size_t) img_width * 4;
+        if (frame.plane_count != 1 ||
+            (frame.fourcc != DRM_FORMAT_XRGB8888 && frame.fourcc != DRM_FORMAT_ARGB8888) ||
+            frame.pitch[0] < row_bytes) {
+          BOOST_LOG(error) << "Hermes-KMS CPU capture: unexpected frame layout (planes="sv << frame.plane_count
+                           << ", fourcc=0x"sv << std::hex << frame.fourcc << std::dec
+                           << ", pitch="sv << frame.pitch[0] << ')';
+          frame.close();
+          return platf::capture_e::error;
+        }
+
+        const size_t map_len = (size_t) frame.pitch[0] * frame.height + frame.offset[0];
+        const off_t dmabuf_size = lseek(frame.dma_buf_fd[0], 0, SEEK_END);
+        if (dmabuf_size > 0 && map_len > (size_t) dmabuf_size) {
+          BOOST_LOG(error) << "Hermes-KMS CPU capture: frame metadata exceeds the DMA-BUF ("sv
+                           << map_len << " > "sv << dmabuf_size << ')';
+          frame.close();
+          return platf::capture_e::error;
+        }
+
+        void *map = mmap(nullptr, map_len, PROT_READ, MAP_SHARED, frame.dma_buf_fd[0], 0);
+        if (map == MAP_FAILED) {
+          BOOST_LOG(error) << "Hermes-KMS CPU capture: mmap failed: "sv << strerror(errno);
+          frame.close();
+          return platf::capture_e::error;
+        }
+
+        // Bracket the CPU read as the DMA-BUF mmap contract requires.
+        struct dma_buf_sync sync;
+        sync.flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_READ;
+        drmIoctl(frame.dma_buf_fd[0], DMA_BUF_IOCTL_SYNC, &sync);
+
+        const auto *src = static_cast<const std::uint8_t *>(map) + frame.offset[0];
+        auto *dst = img_out->data;
+        if (frame.pitch[0] == row_bytes) {
+          std::memcpy(dst, src, row_bytes * img_height);
+        } else {
+          for (int y = 0; y < img_height; ++y) {
+            std::memcpy(dst + (size_t) y * row_bytes, src + (size_t) y * frame.pitch[0], row_bytes);
+          }
+        }
+
+        sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
+        drmIoctl(frame.dma_buf_fd[0], DMA_BUF_IOCTL_SYNC, &sync);
+
+        munmap(map, map_len);
+        last_sequence = frame.sequence;
+        frame.close();
+
+        img_out->frame_timestamp = std::chrono::steady_clock::now();
+        return platf::capture_e::ok;
+      }
+
+      capture_e capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) {
+        while (true) {
+          std::shared_ptr<platf::img_t> img_out;
+          auto status = snapshot(pull_free_image_cb, img_out, 200ms, *cursor);
+          switch (status) {
+            case platf::capture_e::reinit:
+            case platf::capture_e::error:
+            case platf::capture_e::interrupted:
+              return status;
+            case platf::capture_e::timeout:
+              if (!push_captured_image_cb(std::move(img_out), false)) {
+                return platf::capture_e::ok;
+              }
+              break;
+            case platf::capture_e::ok:
+              if (!push_captured_image_cb(std::move(img_out), true)) {
+                return platf::capture_e::ok;
+              }
+              break;
+            default:
+              BOOST_LOG(error) << "Unrecognized capture status ["sv << (int) status << ']';
+              return status;
+          }
+        }
+        return capture_e::ok;
+      }
+
+      int hermes_fd {-1};
+      uint64_t last_sequence {0};
+    };
+
   }  // namespace kms
 
   std::shared_ptr<display_t> kms_display(mem_type_e hwdevice_type, const std::string &display_name, const ::video::config_t &config) {
@@ -1874,11 +2072,25 @@ namespace platf {
     // desktop. Use the dedicated capture path and never fall back to a KMS
     // card, which would stream a physical monitor.
     if (hermes_kms_display) {
-      if (hwdevice_type != mem_type_e::vaapi) {
-        BOOST_LOG(error) << "Hermes-KMS capture requires VAAPI zero-copy; "sv
+      if (hwdevice_type != mem_type_e::vaapi && hwdevice_type != mem_type_e::cuda) {
+        BOOST_LOG(error) << "Hermes-KMS capture requires VAAPI or NVENC(CUDA); "sv
                          << "the selected encoder is not supported."sv;
         return nullptr;
       }
+
+      // NVENC: NVIDIA's EGL import of these system-memory DMA-BUFs reads the
+      // wrong pages beyond the first ones (diagonal-stripe corruption), so
+      // route CUDA sessions through the always-correct CPU copy. VAAPI keeps
+      // the validated zero-copy import.
+      if (hwdevice_type == mem_type_e::cuda) {
+        auto disp = std::make_shared<kms::display_hermes_ram_t>(hwdevice_type);
+        if (!disp->init(display_name, config)) {
+          return disp;
+        }
+        BOOST_LOG(error) << "Hermes-KMS CPU-copy capture failed; refusing physical-display fallback."sv;
+        return nullptr;
+      }
+
       auto disp = std::make_shared<kms::display_hermes_vram_t>(hwdevice_type);
       if (!disp->init(display_name, config)) {
         return disp;

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1940,9 +1940,17 @@ namespace platf {
       }
 
       capture_e snapshot(const pull_free_image_cb_t &pull_free_image_cb, std::shared_ptr<platf::img_t> &img_out, std::chrono::milliseconds timeout, bool /* cursor */) {
+        // Pull the destination image before acquiring, like
+        // display_hermes_vram_t does: the timeout path below re-emits
+        // img_out, so it must already hold a valid image by then.
+        if (!pull_free_image_cb(img_out)) {
+          return platf::capture_e::interrupted;
+        }
+
         VDISPLAY::HermesKmsFrame frame;
         const auto timeout_ms = static_cast<uint32_t>(std::max<std::chrono::milliseconds::rep>(1, timeout.count()));
         if (!VDISPLAY::hermesKmsAcquireFrame(hermes_fd, last_sequence, timeout_ms, frame)) {
+          // No new frame within the timeout: emit the previous image unchanged.
           return platf::capture_e::timeout;
         }
         accumulate_capture_metric("hermes-kms-cpu", frame.acquire_ns);
@@ -1950,11 +1958,6 @@ namespace platf {
         if (frame.width != img_width || frame.height != img_height) {
           frame.close();
           return platf::capture_e::reinit;
-        }
-
-        if (!pull_free_image_cb(img_out)) {
-          frame.close();
-          return platf::capture_e::interrupted;
         }
 
         // A successful ACQUIRE_FRAME only means the frame was exported, not
@@ -2027,7 +2030,7 @@ namespace platf {
         return platf::capture_e::ok;
       }
 
-      capture_e capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) {
+      capture_e capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override {
         while (true) {
           std::shared_ptr<platf::img_t> img_out;
           auto status = snapshot(pull_free_image_cb, img_out, 200ms, *cursor);


### PR DESCRIPTION
Third part of the split requested in the #16 review: the NVENC capture path, with the synchronization blocker fixed as described there.

NVIDIA's EGL import of the Hermes-KMS system-memory DMA-BUFs reads the wrong pages beyond the first ones (diagonal-stripe corruption), so NVENC sessions capture through a CPU copy of the scanout buffer (`display_hermes_ram_t`) and feed the regular RAM-to-CUDA upload path. VAAPI keeps the validated zero-copy import. Costs one memcpy per frame (~1-2 ms at 1440p-class sizes).

Review points addressed in the copy path:

- **Fence wait**: the snapshot now waits (poll) on the exported sync file before touching the pixels; the incorrect comment claiming x86 coherence made the fence unnecessary is gone. A fence that does not signal within the snapshot timeout drops the frame instead of reading a potentially incomplete one.
- **DMA-BUF mmap contract**: the CPU read is bracketed with `DMA_BUF_IOCTL_SYNC` (`START|READ` / `END|READ`), same as the existing cursor-plane path.
- **Metadata validation**: before mapping, the frame must be single-plane XRGB8888/ARGB8888 with `pitch >= width*4`, and the computed mapping size is checked against the actual DMA-BUF size (lseek).

Status: builds clean with CUDA on; the original CPU-copy path was streamed end to end on Nobara 44 (KDE Wayland, RTX 5060 Ti, driver 580 series, CUDA 13). I have not yet re-run the full end-to-end stream with the new fence wait in place and will confirm that in a comment here. On hardware coverage: I can test CUDA 12 builds in a container, but validation on pre-Blackwell NVIDIA generations will need other testers.