### PR TITLE
linux: EGL import fallback and CUDA interop groundwork for NVIDIA

### DIFF
--- a/src/platform/linux/graphics.cpp
+++ b/src/platform/linux/graphics.cpp
@@ -534,6 +534,40 @@ namespace egl {
     return attribs;
   }
 
+  /**
+   * @brief Bind an EGLImage to the currently bound GL_TEXTURE_2D.
+   *
+   * Tries the GLES-style OES bind first, then falls back to
+   * GL_EXT_EGL_image_storage. NVIDIA's desktop-GL driver rejects the OES bind
+   * for foreign (system-memory) DMA-BUF imports such as Hermes-KMS frames with
+   * GL_INVALID_OPERATION, but accepts the immutable-storage bind.
+   */
+  bool bind_egl_image_texture_2d(EGLImage image) {
+    // Drain stale errors so the check below sees only this bind.
+    while (gl::ctx.GetError() != GL_NO_ERROR) {}
+
+    gl::ctx.EGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
+    if (gl::ctx.GetError() == GL_NO_ERROR) {
+      return true;
+    }
+
+    using tex_storage_fn = void(GLAPIENTRY *)(GLenum, void *, const GLint *);
+    static auto tex_storage = (tex_storage_fn) eglGetProcAddress("glEGLImageTargetTexStorageEXT");
+    if (!tex_storage) {
+      BOOST_LOG(error) << "EGLImage bind failed and glEGLImageTargetTexStorageEXT is unavailable"sv;
+      return false;
+    }
+
+    tex_storage(GL_TEXTURE_2D, image, nullptr);
+    if (gl::ctx.GetError() != GL_NO_ERROR) {
+      BOOST_LOG(error) << "EGLImage bind failed through both OES and TexStorageEXT paths"sv;
+      return false;
+    }
+
+    BOOST_LOG(debug) << "EGLImage bound via glEGLImageTargetTexStorageEXT fallback"sv;
+    return true;
+  }
+
   std::optional<rgb_t> import_source(display_t::pointer egl_display, const surface_descriptor_t &xrgb) {
     auto attribs = surface_descriptor_to_egl_attribs(xrgb);
 
@@ -550,7 +584,10 @@ namespace egl {
     }
 
     gl::ctx.BindTexture(GL_TEXTURE_2D, rgb->tex[0]);
-    gl::ctx.EGLImageTargetTexture2DOES(GL_TEXTURE_2D, rgb->xrgb8);
+    if (!bind_egl_image_texture_2d(rgb->xrgb8)) {
+      gl::ctx.BindTexture(GL_TEXTURE_2D, 0);
+      return std::nullopt;
+    }
 
     gl::ctx.BindTexture(GL_TEXTURE_2D, 0);
 
@@ -608,10 +645,14 @@ namespace egl {
     }
 
     gl::ctx.BindTexture(GL_TEXTURE_2D, nv12->tex[0]);
-    gl::ctx.EGLImageTargetTexture2DOES(GL_TEXTURE_2D, nv12->r8);
+    if (!bind_egl_image_texture_2d(nv12->r8)) {
+      return std::nullopt;
+    }
 
     gl::ctx.BindTexture(GL_TEXTURE_2D, nv12->tex[1]);
-    gl::ctx.EGLImageTargetTexture2DOES(GL_TEXTURE_2D, nv12->bg88);
+    if (!bind_egl_image_texture_2d(nv12->bg88)) {
+      return std::nullopt;
+    }
 
     nv12->buf.bind(std::begin(nv12->tex), std::end(nv12->tex));
 

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1725,6 +1725,13 @@ namespace platf {
         }
 #endif
 
+#ifndef SUNSHINE_BUILD_CUDA
+        if (mem_type == mem_type_e::cuda) {
+          BOOST_LOG(warning) << "Hermes-KMS NVENC path requested but Hermes was built without CUDA support."sv;
+          return -1;
+        }
+#endif
+
         BOOST_LOG(info) << "Hermes-KMS zero-copy capture ready: "sv << w << 'x' << h;
         return 0;
       }
@@ -1771,7 +1778,21 @@ namespace platf {
           return va::make_avcodec_encode_device(width, height, dup(encode_render_fd.el), img_offset_x, img_offset_y, true);
         }
 #endif
-        BOOST_LOG(error) << "Hermes-KMS capture only supports VAAPI encoding."sv;
+#ifdef SUNSHINE_BUILD_CUDA
+        if (mem_type == mem_type_e::cuda) {
+          // Same descriptor flow as display_vram_t: the GL/CUDA device imports
+          // the Hermes DMA-BUFs through EGL on the NVIDIA GPU and encodes with
+          // NVENC. The Hermes render node stays capture-only.
+          //
+          // NOTE: NVENC sessions for Hermes-KMS displays currently capture
+          // through a CPU copy, because NVIDIA's EGL import of these
+          // system-memory DMA-BUFs reads wrong pages past the first ones.
+          // This branch is the intended zero-copy path once that import is
+          // reliable and is kept buildable on purpose.
+          return cuda::make_avcodec_gl_encode_device(width, height, img_offset_x, img_offset_y);
+        }
+#endif
+        BOOST_LOG(error) << "Hermes-KMS capture supports VAAPI and NVENC(CUDA) encoding only."sv;
         return nullptr;
       }
 


### PR DESCRIPTION
Fourth part of the split requested in the #16 review: the CUDA and EGL interoperability changes that are independent of the capture rework.

- **EGL import fallback** (`bind_egl_image_texture_2d`): NVIDIA's desktop-GL driver rejects the GLES-style OES bind for foreign system-memory DMA-BUF imports with `GL_INVALID_OPERATION`, but accepts the `GL_EXT_EGL_image_storage` immutable bind. All EGL capture paths (physical KMS, Wayland, Hermes-KMS) go through the fallback now instead of silently producing a broken texture.
- **CUDA branch in `display_hermes_vram_t`**: same descriptor flow as `display_vram_t`. To your question in the review: this path is intentionally not reachable for Hermes-KMS NVENC sessions right now, because NVIDIA's EGL import of these buffers reads wrong pages past the first ones (the finding documented in the Hermes-KMS `tools/` PR). NVENC sessions use the CPU-copy path instead; this branch is the intended zero-copy path once the import is reliable, and the code comment now says exactly that.
- **Clean refusal** of CUDA sessions when Hermes was built without CUDA support.

Builds clean with `SUNSHINE_ENABLE_CUDA=ON`; the no-CUDA variant only differs by preprocessor guards, but I have not built it separately yet. The EGL fallback is exercised on every NVIDIA capture; the vram CUDA branch is compile-verified groundwork by design.
