### PR TITLE
docs: isolated_virtual_display_option is not Windows-only

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1856,8 +1856,13 @@ editing the `conf` file in a text editor. Use the examples as reference.
     <tr>
         <td>Description</td>
         <td colspan="2">
-            Isolates the virtual display.
-            @note{Applies to Windows only.}
+            Isolates the virtual display, so the streamed session is the only
+            active output for its duration.
+            @note{On Linux, this requires a compositor with output management
+            (KScreen/KWin, or a Wayland compositor implementing output
+            management). If it is unavailable, Hermes logs a warning and
+            continues with the virtual display alongside the physical
+            outputs.}
         </td>
     </tr>
     <tr>
@@ -1866,7 +1871,15 @@ editing the `conf` file in a text editor. Use the examples as reference.
     </tr>
     <tr>
         <td>enabled</td>
-        <td>Change the position of the virtual display (and other displays if there is a hole)</td>
+        <td>
+            <b>Windows:</b> change the position of the virtual display (and other
+            displays if there is a hole).
+            <br>
+            <b>Linux:</b> disable the physical outputs for the duration of the
+            session and restore the previous layout when it ends. Windows already
+            on the desktop, including a running fullscreen game, move onto the
+            virtual display.
+        </td>
     </tr>
 </table>
 


### PR DESCRIPTION
## Problem

`docs/configuration.md` describes `isolated_virtual_display_option` as:

> Isolates the virtual display.
> @note{Applies to Windows only.}

The Linux implementation exists and works.

`src/process.cpp` calls it from the non-Windows branch:

```cpp
if (virtual_display_ready_for_capture && config::video.isolated_virtual_display_option == true) {
#ifdef _WIN32
    VDISPLAY::changeDisplaySettings2(...);
#else
    VDISPLAY::changeDisplaySettings2(...);
    if (!VDISPLAY::enableExclusiveVirtualDisplay(vdisplayName)) {
      BOOST_LOG(warning) << "Virtual display is active, but exclusive mode could not disable physical outputs.";
    }
#endif
}
```

And `src/platform/linux/virtual_display.cpp` implements it fully — `enableExclusiveVirtualDisplay()` → `kscreen::make_exclusive()` disables the physical outputs via `kscreen-doctor`, persists their prior priorities for crash recovery, and `restoreExclusiveVirtualDisplay()` restores the layout when the session ends.

## Why this is worth fixing

This is the setting that makes an already-running fullscreen game move onto the virtual display. Without it, the virtual display is just an extra monitor and the game stays on the physical one — the most common "streaming works but I'm looking at the wrong screen" confusion.

Because the note reads as authoritative, a Linux user searching the reference for exactly this problem is told the solution doesn't apply to them.

## Change

Documents the per-platform behaviour rather than claiming the option is Windows-only, and states the Linux requirement (a compositor with output management) plus the fallback when it's absent. Docs only — no code changes.

## Verification

KDE Plasma 6.7 Wayland, CachyOS, kernel 7.1.6, AMD RX 9070 XT, Hermes 0.5.0 with the Hermes-KMS backend. Enabling the option disables the physical outputs for the duration of a stream and restores the previous layout afterwards, exactly as the updated text describes.
