### PR TITLE
fix(virtual_display): correct evdi_add_device() failure check

### DIFF
--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -2634,10 +2634,16 @@ namespace VDISPLAY {
 
     // evdi_add_device() reports a successful sysfs write, not the EVDI device
     // index. Rescan check_device() to find the index assigned by the kernel.
+    //
+    // libevdi's write_add_device() returns fwrite()'s result for a 1-byte
+    // buffer: exactly 1 on a successful sysfs write, 0 on any failure
+    // (fopen("/sys/devices/evdi/add", "w") failing, or the write itself
+    // failing). It never returns a negative value, so the previous
+    // `result < 0` check could never fire and silently swallowed every
+    // real failure, leaving the caller to poll for a device that was
+    // never created.
     const int result = evdi.add_device();
-    // libevdi returns 0 when the sysfs request succeeds. It does not return
-    // the device index, so only negative values are failures.
-    if (result < 0) {
+    if (result != 1) {
       BOOST_LOG(warning) << "[VDISPLAY] evdi_add_device() failed (returned " << result << ").";
       return -1;
     }


### PR DESCRIPTION
## Summary

`write_add_device()` in libevdi returns `fwrite()`'s result for a 1-byte
buffer: exactly `1` on a successful sysfs write to
`/sys/devices/evdi/add`, and `0` on any failure (`fopen()` failing, or
the write itself failing). It never returns a negative value.

`evdi_add_device()` is loaded directly via `dlsym` as a thin function
pointer (`fn_evdi_add_device`) with no wrapper in between, so it
passes this return value straight through unchanged.

The existing check:

```cpp
if (result < 0) {
  BOOST_LOG(warning) << "[VDISPLAY] evdi_add_device() failed (returned " << result << ").";
  return -1;
}
```

can therefore never fire on a real failure, since a failed write
returns exactly `0`, not a negative number. This silently swallows
every real failure and lets `find_available_evdi_device()` fall
through to polling for a device that was never actually created,
eventually failing with the misleading "No EVDI device became
available after creation" warning instead of surfacing the real
cause of the failure.

Fixed by checking `result != 1` instead.

## Test plan

- Reproduced on a rootless podman container attached to a live KDE
  Plasma/KWin session: with the sysfs `add` write silently failing,
  the old code proceeded into the device-index poll loop and timed
  out after ~2.5s with the misleading message above; no warning about
  `evdi_add_device()` itself was ever logged.
- After the fix, a genuine write failure now correctly logs
  `evdi_add_device() failed (returned 0).` immediately instead of
  masking it behind an unrelated timeout.
- Verified end-to-end EVDI virtual display creation, KScreen
  output enable, and a live streaming session (video + audio + input)
  still succeed normally once the underlying sysfs write actually
  succeeds.