### PR TITLE
VDISPLAY: Add Hyprland headless backend support in openVDisplayDevice()

### DIFF
--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -4206,6 +4206,23 @@ namespace VDISPLAY {
       return driver_status;
     }
 
+    if (backend == VirtualDisplayBackend::HYPRLAND_HEADLESS) {
+      evdi_available = false;
+      unload_evdi_library();
+      if (!hyprland::available()) {
+        BOOST_LOG(warning) << "[VDISPLAY] The session is Hyprland but its control socket is not reachable. "
+                            "Hermes reads HYPRLAND_INSTANCE_SIGNATURE from its own environment, so a "
+                            "service started outside the session will not find it.";
+        driver_status = DRIVER_STATUS::NOT_SUPPORTED;
+        return driver_status;
+      }
+
+      driver_status = DRIVER_STATUS::OK;
+      device_open = true;
+      BOOST_LOG(info) << "[VDISPLAY] Hyprland headless output backend available - virtual displays supported.";
+      return driver_status;
+    }
+
     // Try to load EVDI library
     evdi_available = load_evdi_library();
 


### PR DESCRIPTION
## Summary
When running on Hyprland, `selected_backend()` correctly returns `HYPRLAND_HEADLESS`, but `openVDisplayDevice()` lacked a case to handle this backend. This caused it to fall through to the EVDI code path, which fails with "EVDI is unavailable" if libevdi is not installed - even though Hyprland's headless output backend doesn't require EVDI at all.

## Changes
- Added `HYPRLAND_HEADLESS` case in `openVDisplayDevice()` (src/platform/linux/virtual_display.cpp)
- Checks `hyprland::available()` (control socket reachable) before enabling
- Properly initializes driver status without requiring EVDI or hermes-kms

## Testing
- Verified on Hyprland with Moonlight/iPhone client
- Virtual display created as `HEADLESS-1` at client-requested resolution (1920x1080@60)
- Physical display disabled during session, restored on disconnect
- Session assessment shows: virtual display=ready, client-requested mode=ready, exclusive mode=ready

## Related
- `createVirtualDisplay()` already handles Hyprland headless path (line 4426)
- `selected_backend()` already returns `HYPRLAND_HEADLESS` for Hyprland sessions (line 257)