### PR TITLE
fix(wayland): allocate screencopy buffers on the compositor's GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -623,6 +623,18 @@ run `scripts/bump-version.sh <major|minor|patch>` — it moves everything under
   and choosing "IPv4 only" wrote nothing and changed nothing. The two defaults
   agree again.
 
+- Wayland screencopy capture on a multi-GPU host allocates its buffers on the
+  GPU the compositor renders with, learned from linux-dmabuf default feedback,
+  before consulting `WLR_RENDER_DRM_DEVICE` or scanning render nodes. The scan
+  keeps the first node that can allocate a buffer, and on an Intel + NVIDIA
+  desktop with Hyprland on the NVIDIA card that is the Intel iGPU: its buffer
+  allocates fine and Hyprland then refuses to import it with a fatal protocol
+  error. That error was invisible, because the Wayland connection was never
+  checked for one; every frame looked like a timeout and the client got a black
+  stream with working audio and input. A dead connection is now logged once,
+  ends capture on a protocol error, and reinitialises it on any other loss.
+  `adapter_name` still wins when set, with a warning if it names another GPU
+  ([#34], [#29]).
 - A session no longer crashes the server when the control port cannot be bound.
   `net::host_create` set a socket option on the result of `enet_host_create`
   before checking it, and enet returns null whenever it cannot create or bind
@@ -1255,6 +1267,7 @@ run `scripts/bump-version.sh <major|minor|patch>` — it moves everything under
 [#25]: https://github.com/MrOz59/Hermes/issues/25
 [#28]: https://github.com/MrOz59/Hermes/issues/28
 [#29]: https://github.com/MrOz59/Hermes/issues/29
+[#34]: https://github.com/MrOz59/Hermes/issues/34
 
 ## [0.4.0] - 2026-07-02
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -211,10 +211,15 @@ path, not a mock: the output is created, the client's mode is applied and read
 back from the compositor, capture initialises on it at that mode, and removing
 the display leaves the session as it was.
 
-Where the verification stops: **no full stream to a client has been completed
-yet.** Capture initialising is not the same as frames reaching Moonlight, and
-the pacing question below is open — a headless output redraws on damage, so a
-still screen may not produce frames at the requested rate on its own.
+Where the verification stands: **a full stream to a client was completed on
+2026-09-01** on Arch Linux (Omarchy), kernel 7.1.9, Hyprland 0.56.2, Intel UHD
+770 plus NVIDIA RTX 4080 SUPER (driver 610.57) with Hyprland rendering on the
+NVIDIA card, NVENC, to a Hestia client over LAN, on the physical monitor and on
+a headless output alike, once screencopy buffers were allocated on the GPU the
+compositor renders with (see the known limitation below). The pacing question
+below is still open: the frame rate was not measured, and a headless output
+redraws on damage, so a still screen may not produce frames at the requested
+rate on its own.
 
 Hermes does not give Hyprland a virtual DRM device. It asks Hyprland to create a
 **headless output**, which Hyprland renders itself on the primary GPU — so the
@@ -471,6 +476,16 @@ compositor" for an output the same log had just listed. Only the Hyprland
 headless path selects by name — a physical monitor is selected by index — so
 this never surfaced before. Fixed; noted here because the error message points
 at the compositor and the fault was Hermes'.
+
+**On a multi-GPU host, Wayland screencopy capture allocates on the GPU the
+compositor renders with.** The render-node scan used to keep the first node that
+could allocate a buffer, and on an Intel + NVIDIA desktop with Hyprland on the
+NVIDIA card that was the Intel iGPU; Hyprland refused the buffer with a fatal
+`zwp_linux_buffer_params_v1` protocol error that nothing read, and the client got
+a black stream with working audio and input. The compositor's device now comes
+from linux-dmabuf default feedback (protocol v4 and later); on a compositor below
+v4 the scan still runs, and `adapter_name = /dev/dri/renderDNN` names the right
+card by hand.
 
 **The development udev rule hides the card from every compositor.**
 `udev/99-hermes-kms-ignore-seat.rules` strips `TAG+="seat"` and `ID_SEAT` from

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -556,7 +556,8 @@ namespace wl {
       this->interface[WLR_EXPORT_DMABUF] = true;
     } else if (!std::strcmp(interface, zwp_linux_dmabuf_v1_interface.name)) {
       BOOST_LOG(info) << "Found interface: "sv << interface << '(' << id << ") version "sv << version;
-      dmabuf_interface = (zwp_linux_dmabuf_v1 *) wl_registry_bind(registry, id, &zwp_linux_dmabuf_v1_interface, version);
+      // Never bind a version newer than the generated code knows about.
+      dmabuf_interface = (zwp_linux_dmabuf_v1 *) wl_registry_bind(registry, id, &zwp_linux_dmabuf_v1_interface, std::min<std::uint32_t>(version, zwp_linux_dmabuf_v1_interface.version));
 
       this->interface[LINUX_DMABUF] = true;
     } else if (!std::strcmp(interface, ext_image_copy_capture_manager_v1_interface.name)) {

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -5,6 +5,7 @@
 // standard includes
 #include <algorithm>
 #include <atomic>
+#include <cerrno>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
@@ -21,6 +22,8 @@
 #include <fcntl.h>
 #include <gbm.h>
 #include <poll.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <wayland-client.h>
 #include <wayland-util.h>
@@ -88,7 +91,8 @@ namespace wl {
   /**
    * @brief Waits up to the specified timeout to dispatch new events on the wl_display.
    * @param timeout The timeout in milliseconds.
-   * @return `true` if new events were dispatched or `false` if the timeout expired.
+   * @return `true` if new events were dispatched, `false` if the timeout expired
+   *         or the connection is dead; connection_error() tells the two apart.
    */
   bool display_t::dispatch(std::chrono::milliseconds timeout) {
     // Check if any events are queued already. If not, flush
@@ -100,9 +104,14 @@ namespace wl {
       struct pollfd pfd = {};
       pfd.fd = wl_display_get_fd(display_internal.get());
       pfd.events = POLLIN;
-      if (poll(&pfd, 1, timeout.count()) == 1 && (pfd.revents & POLLIN)) {
-        // Read the new event(s)
-        wl_display_read_events(display_internal.get());
+      // A hang-up or error without POLLIN still has to reach read_events, so
+      // the connection error is recorded instead of looking like a timeout.
+      if (poll(&pfd, 1, timeout.count()) == 1 && (pfd.revents & (POLLIN | POLLHUP | POLLERR))) {
+        // Read the new event(s). -1 only ever means the connection is dead.
+        if (wl_display_read_events(display_internal.get()) < 0) {
+          connection_error();
+          return false;
+        }
       } else {
         // We timed out, so unlock the queue now
         wl_display_cancel_read(display_internal.get());
@@ -110,9 +119,30 @@ namespace wl {
       }
     }
 
-    // Dispatch any existing or new pending events
-    wl_display_dispatch_pending(display_internal.get());
+    // Dispatch any existing or new pending events. -1 means the connection is dead.
+    if (wl_display_dispatch_pending(display_internal.get()) < 0) {
+      connection_error();
+      return false;
+    }
     return true;
+  }
+
+  int display_t::connection_error() {
+    auto err = wl_display_get_error(display_internal.get());
+    if (err && !error_logged) {
+      error_logged = true;
+      if (err == EPROTO) {
+        const wl_interface *iface = nullptr;
+        std::uint32_t id = 0;
+        auto code = wl_display_get_protocol_error(display_internal.get(), &iface, &id);
+        BOOST_LOG(error) << "Wayland connection lost to a protocol error: "sv
+                         << (iface ? iface->name : "unknown") << '#' << id << " error "sv << code
+                         << ". Capture cannot continue on this connection."sv;
+      } else {
+        BOOST_LOG(error) << "Wayland connection lost: "sv << std::strerror(err);
+      }
+    }
+    return err;
   }
 
   wl_registry *display_t::registry() {
@@ -664,6 +694,114 @@ namespace wl {
     return device;
   }
 
+  namespace {
+    struct feedback_ctx_t {
+      dev_t main_device {};
+      bool have_main_device {false};
+      bool done {false};
+    };
+
+    void feedback_done(void *data, zwp_linux_dmabuf_feedback_v1 *) {
+      static_cast<feedback_ctx_t *>(data)->done = true;
+    }
+
+    void feedback_format_table(void *, zwp_linux_dmabuf_feedback_v1 *, std::int32_t fd, std::uint32_t) {
+      close(fd);
+    }
+
+    void feedback_main_device(void *data, zwp_linux_dmabuf_feedback_v1 *, wl_array *device) {
+      auto ctx = static_cast<feedback_ctx_t *>(data);
+      if (device->size == sizeof(dev_t)) {
+        std::memcpy(&ctx->main_device, device->data, sizeof(dev_t));
+        ctx->have_main_device = true;
+      }
+    }
+
+    void feedback_tranche_done(void *, zwp_linux_dmabuf_feedback_v1 *) {}
+
+    void feedback_tranche_target_device(void *, zwp_linux_dmabuf_feedback_v1 *, wl_array *) {}
+
+    void feedback_tranche_formats(void *, zwp_linux_dmabuf_feedback_v1 *, wl_array *) {}
+
+    void feedback_tranche_flags(void *, zwp_linux_dmabuf_feedback_v1 *, std::uint32_t) {}
+
+    const zwp_linux_dmabuf_feedback_v1_listener feedback_listener {
+      .done = feedback_done,
+      .format_table = feedback_format_table,
+      .main_device = feedback_main_device,
+      .tranche_done = feedback_tranche_done,
+      .tranche_target_device = feedback_tranche_target_device,
+      .tranche_formats = feedback_tranche_formats,
+      .tranche_flags = feedback_tranche_flags,
+    };
+
+    /**
+     * @brief The node to allocate on for the DRM device that owns a device number.
+     *
+     * A compositor names its GPU by number and may name either its primary or
+     * its render node, so the number is resolved through libdrm rather than
+     * used as a path. The answer is the render node, or the primary node for a
+     * driver that exposes no render node: GBM can allocate there too, and
+     * init_gbm() proves whichever node comes back before trusting it.
+     * @return The node's path, or an empty string when no DRM device owns the number.
+     */
+    std::string render_node_for_device(dev_t device_id) {
+      drmDevice *drm_device {nullptr};
+      if (drmGetDeviceFromDevId(device_id, 0, &drm_device) != 0) {
+        BOOST_LOG(warning) << "No DRM device found for device number "sv << major(device_id) << ':' << minor(device_id);
+        return {};
+      }
+      std::string node;
+      if (drm_device->available_nodes & (1 << DRM_NODE_RENDER)) {
+        node = drm_device->nodes[DRM_NODE_RENDER];
+      } else if (drm_device->available_nodes & (1 << DRM_NODE_PRIMARY)) {
+        node = drm_device->nodes[DRM_NODE_PRIMARY];
+      }
+      drmFreeDevice(&drm_device);
+      return node;
+    }
+  }  // namespace
+
+  std::string compositor_render_node(display_t &display, zwp_linux_dmabuf_v1 *dmabuf_interface) {
+    if (!display.get() || !dmabuf_interface) {
+      return {};
+    }
+    if (zwp_linux_dmabuf_v1_get_version(dmabuf_interface) < ZWP_LINUX_DMABUF_V1_GET_DEFAULT_FEEDBACK_SINCE_VERSION) {
+      BOOST_LOG(info) << "linux-dmabuf v"sv << zwp_linux_dmabuf_v1_get_version(dmabuf_interface)
+                      << " has no feedback; cannot learn which GPU the compositor renders on"sv;
+      return {};
+    }
+
+    feedback_ctx_t ctx;
+    auto feedback = zwp_linux_dmabuf_v1_get_default_feedback(dmabuf_interface);
+    zwp_linux_dmabuf_feedback_v1_add_listener(feedback, &feedback_listener, &ctx);
+    auto roundtrip = wl_display_roundtrip(display.get());
+    zwp_linux_dmabuf_feedback_v1_destroy(feedback);
+
+    if (roundtrip < 0) {
+      BOOST_LOG(warning) << "Wayland connection failed while reading linux-dmabuf feedback"sv;
+      return {};
+    }
+    if (!ctx.done) {
+      BOOST_LOG(warning) << "The compositor did not finish sending linux-dmabuf feedback"sv;
+      return {};
+    }
+    if (!ctx.have_main_device) {
+      BOOST_LOG(warning) << "The compositor sent no linux-dmabuf main device"sv;
+      return {};
+    }
+
+    auto node = render_node_for_device(ctx.main_device);
+    if (!node.empty()) {
+      BOOST_LOG(info) << "The compositor renders on "sv << node << " (linux-dmabuf feedback)"sv;
+    }
+    return node;
+  }
+
+  void dmabuf_t::set_render_node(std::string node) {
+    render_node = std::move(node);
+  }
+
   /**
    * @brief Pick the render node the capture buffers will be allocated on.
    *
@@ -677,8 +815,13 @@ namespace wl {
    * probe green, because an encoder probe never touches this path.
    *
    * The node is therefore taken, in order, from what the user configured, from
-   * what the wlroots compositor was told to render on, and finally from a scan
-   * that keeps the first device able to produce a buffer.
+   * what the compositor itself said it renders on (linux-dmabuf feedback, see
+   * compositor_render_node()), from what the wlroots compositor was told to
+   * render on, and finally from a scan that keeps the first device able to
+   * produce a buffer. That scan is the last resort for a reason: a buffer the
+   * wrong GPU produced perfectly well is still one the compositor cannot
+   * import, and on Hyprland that import failure is a fatal protocol error, not
+   * a failed frame.
    */
   bool dmabuf_t::init_gbm() {
     if (gbm_device) {
@@ -695,7 +838,24 @@ namespace wl {
         return false;
       }
       BOOST_LOG(info) << "GBM capture device: "sv << node << " (adapter_name)"sv;
+      // Compared by device, not by path: adapter_name may be a symlink to the
+      // node the compositor named, or that GPU's primary node.
+      struct stat st {};
+      if (!render_node.empty() && stat(node.c_str(), &st) == 0 && render_node_for_device(st.st_rdev) != render_node) {
+        BOOST_LOG(warning) << "adapter_name "sv << node << " is not the GPU the compositor renders on ("sv
+                           << render_node << "); the compositor may refuse buffers allocated there."sv;
+      }
       return true;
+    }
+
+    if (!render_node.empty()) {
+      gbm_device = open_usable_gbm_device(render_node.c_str(), drm_fd);
+      if (gbm_device) {
+        BOOST_LOG(info) << "GBM capture device: "sv << render_node << " (named by the compositor)"sv;
+        return true;
+      }
+      BOOST_LOG(warning) << "The compositor renders on "sv << render_node
+                         << ", which cannot allocate capture buffers; searching the other render nodes."sv;
     }
 
     // A wlroots compositor renders the captured output on this node whenever the
@@ -1333,15 +1493,10 @@ namespace wl {
 
   void dmabuf_t::icc_session_dmabuf_device(ext_image_copy_capture_session_v1 *session, struct wl_array *device) {
     icc_begin_constraints();
-    // This is the one thing screencopy never tells us: the compositor names the
-    // device it renders on, which is the answer init_gbm() otherwise has to
-    // guess at. Trust it, but prove it the same way - a named device that cannot
-    // allocate is still no use, and falling through to the search leaves the
-    // hybrid-GPU case working rather than trading one wrong node for another.
-    if (gbm_device) {
-      return;
-    }
-
+    // The compositor names the device it renders on, per session, which is the
+    // answer init_gbm() otherwise has to guess at. It is trusted the same way
+    // as the linux-dmabuf feedback answer: init_gbm() proves the node can
+    // allocate and falls through to the search when it cannot.
     if (device->size != sizeof(dev_t)) {
       BOOST_LOG(warning) << "Capture session named a device of "sv << device->size
                          << " bytes, expected "sv << sizeof(dev_t) << "; searching instead."sv;
@@ -1350,31 +1505,7 @@ namespace wl {
 
     dev_t device_id;
     std::memcpy(&device_id, device->data, sizeof(dev_t));
-
-    drmDevice *drm_device {nullptr};
-    if (drmGetDeviceFromDevId(device_id, 0, &drm_device) != 0) {
-      BOOST_LOG(warning) << "Capture session named a DRM device that could not be opened; searching instead."sv;
-      return;
-    }
-
-    const char *node {nullptr};
-    if (drm_device->available_nodes & (1 << DRM_NODE_RENDER)) {
-      node = drm_device->nodes[DRM_NODE_RENDER];
-    } else if (drm_device->available_nodes & (1 << DRM_NODE_PRIMARY)) {
-      node = drm_device->nodes[DRM_NODE_PRIMARY];
-    }
-
-    if (node) {
-      gbm_device = open_usable_gbm_device(node, drm_fd);
-      if (gbm_device) {
-        BOOST_LOG(info) << "GBM capture device: "sv << node << " (named by the compositor)"sv;
-      } else {
-        BOOST_LOG(warning) << "The compositor renders on "sv << node
-                           << ", which cannot allocate capture buffers; searching the other render nodes."sv;
-      }
-    }
-
-    drmFreeDevice(&drm_device);
+    set_render_node(render_node_for_device(device_id));
   }
 
   void dmabuf_t::icc_session_dmabuf_format(ext_image_copy_capture_session_v1 *session, std::uint32_t format, struct wl_array *modifiers) {

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -63,6 +63,11 @@ namespace wl {
     dmabuf_t &operator=(dmabuf_t &&) = delete;
 
     void listen(zwlr_screencopy_manager_v1 *screencopy_manager, zwp_linux_dmabuf_v1 *dmabuf_interface, wl_output *output, bool blend_cursor = false);
+    /**
+     * @brief Name the render node the compositor renders on, so init_gbm()
+     * allocates there. See compositor_render_node().
+     */
+    void set_render_node(std::string node);
     static void buffer_params_created(void *data, struct zwp_linux_buffer_params_v1 *params, struct wl_buffer *wl_buffer);
     static void buffer_params_failed(void *data, struct zwp_linux_buffer_params_v1 *params);
 
@@ -163,6 +168,8 @@ namespace wl {
     // gbm_create_device() borrows the fd, it does not adopt it, so the device
     // cannot be the only thing holding on to it.
     int drm_fd {-1};
+    // Render node the compositor renders on, when it told us; empty otherwise.
+    std::string render_node;
     struct gbm_bo *current_bo {nullptr};
     struct wl_buffer *current_wl_buffer {nullptr};
     bool y_invert {false};
@@ -258,8 +265,17 @@ namespace wl {
     // Roundtrip with Wayland connection
     void roundtrip();
 
-    // Wait up to the timeout to read and dispatch new events
+    // Wait up to the timeout to read and dispatch new events. Returns false on
+    // a timeout and on a dead connection; connection_error() tells the two apart.
     bool dispatch(std::chrono::milliseconds timeout);
+
+    /**
+     * @brief The errno-style code of the connection's fatal error, 0 for none.
+     * A protocol error (EPROTO) is fatal for the whole connection: no further
+     * event is ever delivered, so waiting on one looks exactly like a timeout.
+     * The first call after the error logs it, later calls only report it.
+     */
+    int connection_error();
 
     // Get the registry associated with the display
     // No need to manually free the registry
@@ -271,9 +287,21 @@ namespace wl {
 
   private:
     display_internal_t display_internal;
+    bool error_logged {false};
   };
 
   std::vector<std::unique_ptr<monitor_t>> monitors(const char *display_name = nullptr);
+
+  /**
+   * @brief Ask the compositor which GPU it renders on.
+   *
+   * linux-dmabuf default feedback (protocol v4 and later) names the device the
+   * compositor imports buffers into; screencopy itself never says. Performs a
+   * roundtrip on the display.
+   * @return The render node of that device, or an empty string when the
+   *         compositor did not say or the protocol is too old.
+   */
+  std::string compositor_render_node(display_t &display, zwp_linux_dmabuf_v1 *dmabuf_interface);
   /**
    * Configure a virtual output through wlroots' output-management protocol.
    * Returns false when the compositor does not expose that protocol or rejects

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -22,6 +22,13 @@
 // local includes
 #include "graphics.h"
 
+// Declared at global scope so a translation unit that never includes <gbm.h>
+// agrees with one that does about the type of dmabuf_t's members; otherwise
+// `struct gbm_device *` below declares a wl::gbm_device of its own and LTO
+// reports the mismatch.
+struct gbm_device;
+struct gbm_bo;
+
 /**
  * The classes defined in this macro block should only be used by
  * cpp files whose compilation depends on SUNSHINE_BUILD_WAYLAND

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -4,6 +4,7 @@
  */
 // standard includes
 #include <algorithm>
+#include <cerrno>
 #include <cstdlib>
 #include <cstring>
 #include <thread>
@@ -109,6 +110,17 @@ namespace wl {
       }
       display.roundtrip();
 
+      // Capture buffers must be allocated on the GPU the compositor renders
+      // with; ask it which one that is before the first frame is requested.
+      // This performs a roundtrip, so it must not run before the listen()
+      // loop above: a roundtrip while the initial wl_output events are still
+      // unread and unlistened discards them, and the monitor size stays 0x0.
+      // An ICC session names its own device (dmabuf_device), which is the more
+      // precise answer, so only screencopy asks the default feedback.
+      if (!use_icc) {
+        dmabuf.set_render_node(wl::compositor_render_node(display, interface.dmabuf_interface));
+      }
+
       auto monitor = interface.monitors[0].get();
 
       if (!display_name.empty() && display_name.rfind("VIRTUAL-", 0) != 0) {
@@ -203,6 +215,13 @@ namespace wl {
       do {
         auto remaining_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(to - std::chrono::steady_clock::now());
         if (remaining_time_ms.count() < 0 || !display.dispatch(remaining_time_ms)) {
+          // A dead connection never delivers a frame, so it would time out here
+          // on every call forever. A protocol error is a bug on our side that a
+          // reinit would only repeat; anything else (a compositor restart) is
+          // worth reconnecting for.
+          if (auto err = display.connection_error()) {
+            return err == EPROTO ? platf::capture_e::error : platf::capture_e::reinit;
+          }
           return platf::capture_e::timeout;
         }
         // Only while still waiting: icc_capture() arms a frame whenever the

--- a/tests/unit/platform/test_wayland_capture.cpp
+++ b/tests/unit/platform/test_wayland_capture.cpp
@@ -39,6 +39,9 @@ namespace {
   struct session_t {
     wl::display_t display;
     wl::interface_t interface;
+    // The render node the compositor named, as wlr_t::init() learns it; empty
+    // when it did not say.
+    std::string render_node;
 
     static std::unique_ptr<session_t> open() {
       auto session = std::make_unique<session_t>();
@@ -57,6 +60,8 @@ namespace {
         monitor->listen(session->interface.output_manager);
       }
       session->display.roundtrip();
+
+      session->render_node = wl::compositor_render_node(session->display, session->interface.dmabuf_interface);
 
       return session;
     }
@@ -191,6 +196,7 @@ TEST_F(WaylandCaptureTest, ScreencopyStillProducesAFrame) {
 
   auto monitor = session->first_monitor();
   wl::dmabuf_t dmabuf;
+  dmabuf.set_render_node(session->render_node);
 
   dmabuf.listen(
     session->interface.screencopy_manager,
@@ -207,6 +213,17 @@ TEST_F(WaylandCaptureTest, ScreencopyStillProducesAFrame) {
   EXPECT_EQ(sd.height, (std::uint32_t) monitor->viewport.height);
   EXPECT_NE(sd.fourcc, 0u);
   EXPECT_GE(sd.fds[0], 0);
+}
+
+TEST_F(WaylandCaptureTest, CompositorNamesANodeThatCanAllocate) {
+  // The node the compositor renders on is where screencopy buffers get
+  // allocated; one that cannot allocate would send init_gbm() back to the scan
+  // that this answer exists to avoid.
+  if (session->render_node.empty()) {
+    GTEST_SKIP() << "Compositor did not name its render node (linux-dmabuf feedback needs protocol v4)";
+  }
+  EXPECT_TRUE(wl::render_node_can_allocate(session->render_node.c_str()))
+    << session->render_node << " is the GPU the compositor renders on but cannot allocate a buffer";
 }
 
 /**


### PR DESCRIPTION

Fixes #34. Related: #29.

## Problem

On a multi-GPU host, `dmabuf_t::init_gbm()` allocates the wlr-screencopy
capture buffer on the first DRM render node that can produce one. With
Hyprland rendering on NVIDIA and an Intel iGPU enumerated first, the Intel
node allocates fine and Hyprland rejects the buffer with
`zwp_linux_buffer_params_v1#7: error 4: format + modifier pair is not supported`.
That is a fatal protocol error; `display_t::dispatch()` never checked
`wl_display_get_error()`, so every capture looked like a timeout and the
encoder re-sent the blank start-up frame: a black stream, working audio and
input, nothing in the log. Physical outputs and Hyprland headless outputs are
both affected.

6414a983 made the scan prove each node can allocate, which covers #29 (the
wrong node cannot allocate) but not this shape (it can). Sunshine's
`wayland.cpp` now picks the GPU with a connected display
(`platf::resolve_render_device()` from LizardByte/Sunshine#4961, used in
`wayland.cpp` since #5030); asking the
compositor instead also covers headless outputs, where no connector is
involved. Analysis, history and a standalone reproduction are in #34.

## Changes

Two commits. The first is housekeeping that the second needs but that
stands on its own: `wayland.h` names `gbm_device` and `gbm_bo` without
including `<gbm.h>`, so translation units without that header declared
`wl::gbm_device` of their own and LTO reported the mismatch; the types are
now forward-declared at global scope, and `zwp_linux_dmabuf_v1` is bound at
no more than the version the generated protocol code was built from.

The second is the fix:

- **Ask the compositor.** `wl::compositor_render_node()` binds
  `zwp_linux_dmabuf_v1` default feedback (protocol v4+), takes `main_device`
  from the feedback events (waiting for `done`), and resolves it to a render
  node through `drmGetDeviceFromDevId()`. On v3 it returns empty and logs
  that at info; if the compositor names nothing it returns empty with a
  warning.
- **One helper for both backends.** `render_node_for_device()` is the single
  dev_t-to-node lookup; the ext-image-copy-capture session's
  `dmabuf_device` handler now reduces to handing its node to `init_gbm()`,
  so the allocation probe and its log lines are the same whichever protocol
  named the GPU. The default-feedback roundtrip runs only for the screencopy
  backend, since an ICC session names its own device.
- **Order in `init_gbm()`:** `adapter_name` (with a warning if it names a
  different GPU than the compositor, compared through the same lookup so
  symlinks and primary nodes match), then the compositor's node, then
  `WLR_RENDER_DRM_DEVICE`, then the existing scan. The log says
  `GBM capture device: /dev/dri/renderD128 (named by the compositor)`.
- **Detect a dead connection.** `display_t::dispatch()` now checks the
  results of `wl_display_read_events()` and `wl_display_dispatch_pending()`
  and polls for `POLLHUP | POLLERR`; `display_t::connection_error()` returns
  the recorded errno (with interface and id for `EPROTO`) and logs it once.
  `wlr_t::snapshot()` returns `capture_e::error` on a protocol error and
  `capture_e::reinit` on any other loss instead of timing out forever.
- **Tests.** `tests/unit/platform/test_wayland_capture.cpp`: the session
  learns the compositor's node the way `wlr_t::init()` does, a new
  `CompositorNamesANodeThatCanAllocate` checks the allocation probe accepts
  it (skips when the compositor names nothing), and
  `ScreencopyStillProducesAFrame` takes the new path.
- `CHANGELOG.md` under Unreleased, and the Hyprland section plus Known
  limitations of `docs/compatibility.md`.

## Testing

Manual, on the host from #34: Arch Linux (Omarchy), Hyprland 0.56.2,
Intel UHD 770 (`/dev/dri/renderD129`) plus NVIDIA RTX 4080 SUPER
(`/dev/dri/renderD128`, driver 610.57.04, the GPU Hyprland renders on),
NVENC, Hestia v0.1.0 over LAN.

- Before, on stock `main` (d0304894): black stream at a steady low frame
  rate, log says `GBM capture device: /dev/dri/renderD129` and nothing
  further from the capture side until the service was stopped (the attached
  log on #34).
- After, with this branch installed (on its own, and together with the
  other two PRs): the log says
  `GBM capture device: /dev/dri/renderD128 (named by the compositor)` at
  session start and the client receives the desktop, on the physical
  monitor and on a Hyprland headless virtual display. I have been using
  the combined build for day-to-day remote sessions since 2026-09-02.
  Frame rate after the fix was not measured.
- The new error path fired once in normal use: with a virtual display
  streaming, the headless output's `wl_output` globals disappeared
  (Qt clients on the desktop logged
  `qt.qpa.wayland: There are no outputs - creating placeholder screen`;
  I have not found what removed it), Hermes logged
  `Wayland connection lost to a protocol error: zwlr_screencopy_manager_v1#5 error 4294967295`,
  ended the session instead of hanging, and the client reconnected about
  20 s later. Before this change the same event would have been a silent
  black stream.
- Unit tests, run inside the Hyprland session:
  `--gtest_filter='WaylandCapture*:*Wayland*'` 8 passed, 0 failed, 1 skipped
  (no Hermes-KMS node on this host); full suite 277 passed, 0 failed,
  6 skipped, from the test binary built at 5b6a55cdb.
  Builds clean with LTO; `git clang-format --diff` on the branch reports
  nothing.

The streamed builds were on 4973c7da (this branch alone) and de5126f7
(with the other two PRs). The branch was then rebased onto 8508186bc (the
commits since touch neither capture nor input; only `CHANGELOG.md`
conflicted), the changed lines are byte-identical to what
was streamed, and the rebased tree compiles; the unit-test numbers above
are from the rebased commits.

Not tested: a compositor with linux-dmabuf below v4 (fallback to the previous
behaviour plus a log line), the ext-image-copy-capture backend on this host
(it takes the shared helper but not the feedback roundtrip), the
`adapter_name` mismatch warning (on this host
`adapter_name = /dev/dri/renderD129` would exercise it), and the `reinit`
path on a compositor restart (it reuses the existing reinit handling in the
video core).

Written with Claude Code, as I said on #34. What I can stand behind is the
testing above, done by hand on the host described.

## Notes for reviewers

- The feedback roundtrip position in `wlr_t::init()` matters; see the comment
  there.
- Default feedback is global, so a wlroots multi-GPU layout whose output is
  rendered on a secondary GPU is not covered by it; the ICC path's
  per-session `dmabuf_device` is.
- This branch merges on its own. #35's branch touches `CHANGELOG.md`,
  `docs/compatibility.md` and the declarations block of `wayland.h` too,
  so whichever lands second needs a rebase that keeps both sides; no code
  lines overlap. The resolved merge of all three PRs on 8508186bc is
  https://github.com/danielbaldwin47/Hermes/tree/main-plus-fixes, which is
  what I run.