### PR TITLE
fix(input): map absolute input in the compositor's logical space on Wayland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -676,6 +676,27 @@ run `scripts/bump-version.sh <major|minor|patch>` — it moves everything under
   instead of asking for one of its own, which is refused for the same
   all-or-nothing reason.
 
+- Absolute input on wlroots compositors is mapped in the compositor's logical
+  coordinate space. Hyprland and sway spread an absolute device across the
+  logical bounding box of all outputs, in scaled pixels and including a
+  negative origin; the envelope Hermes normalised against mixed each output's
+  logical position with its physical mode size and assumed the layout started
+  at 0,0. On a scaled desktop with a physical monitor and a virtual display
+  both active the cursor therefore reached a different area of the streamed
+  output than the client pointed at, and only turning the physical monitor off
+  made it line up. The envelope is now built from the logical sizes xdg_output
+  reports and, like the GNOME geometry above, expressed in the streamed
+  output's own pixels, so mouse, touch and pen share one mapping.
+
+  The Hyprland virtual output is placed at the logical right edge of the
+  layout instead of past it: the edge was logical x plus mode width, which left
+  a gap after a monitor at any scale other than 1. The output also keeps its
+  mode and scale across a hotplug through a monitor rule of its own. The
+  wlr-output-management state Hermes applies lives in its client connection and
+  is erased when that connection closes, so the next rule reload put the
+  headless output back on the catch-all rule and rescaled it mid-stream
+  ([#35]).
+
 - Five defects in the ext-image-copy-capture backend, found by reviewing it
   after it landed rather than before. The worst one disarmed the protection the
   backend was written around: `icc_capture()` overwrote the reinit that an
@@ -1255,6 +1276,7 @@ run `scripts/bump-version.sh <major|minor|patch>` — it moves everything under
 [#25]: https://github.com/MrOz59/Hermes/issues/25
 [#28]: https://github.com/MrOz59/Hermes/issues/28
 [#29]: https://github.com/MrOz59/Hermes/issues/29
+[#35]: https://github.com/MrOz59/Hermes/issues/35
 
 ## [0.4.0] - 2026-07-02
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -472,6 +472,15 @@ headless path selects by name — a physical monitor is selected by index — so
 this never surfaced before. Fixed; noted here because the error message points
 at the compositor and the fault was Hermes'.
 
+**Absolute input on a wlroots-style compositor is mapped in the compositor's
+logical space.** Hyprland and its relatives spread an absolute pointer device
+across the bounding box of all outputs in logical (scaled) pixels, so on a
+scaled desktop with a physical monitor and a virtual display both active the
+streamed output's offset and the envelope are taken from xdg_output's logical
+layout and expressed in the streamed output's own pixels, the same way the
+GNOME path reads Mutter's logical monitor layout. KMS capture of a physical
+monitor at a scale other than 1 still has the old mismatch.
+
 **The development udev rule hides the card from every compositor.**
 `udev/99-hermes-kms-ignore-seat.rules` strips `TAG+="seat"` and `ID_SEAT` from
 the Hermes-KMS card so an isolated test session can claim it. With that rule

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -535,6 +535,8 @@ namespace platf {
     virtual ~display_t() = default;
 
     // Offsets for when streaming a specific monitor. By default, they are 0.
+    // The offset is relative to the desktop envelope's top-left corner and the
+    // envelope is the whole desktop, both in this display's capture pixels.
     int offset_x, offset_y;
     int env_width, env_height;
 

--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -288,6 +288,10 @@ namespace VDISPLAY {
     return "EVDI";
   }
 
+  // Defined with the KScreen backend below; the Hyprland one interpolates
+  // output names into its socket commands too.
+  static bool safe_output_name(const std::string &name);
+
   /**
    * @brief Hyprland's control socket.
    *
@@ -420,6 +424,69 @@ namespace VDISPLAY {
 
       BOOST_LOG(error) << "[VDISPLAY] Hyprland accepted the headless output but never published it.";
       return std::nullopt;
+    }
+
+    /**
+     * @brief Pin the mode and scale of a headless output with a monitor rule,
+     * so they survive Hyprland re-applying its rules.
+     *
+     * Hyprland applies wlr-output-management state on top of the monitor rule
+     * that matches the output, but that state lives in the requesting
+     * client's manager object and is erased when the client disconnects.
+     * configure_virtual_output() destroys its connection on return, so the
+     * next rule reload - a physical display powering off is enough, and so is
+     * a config reload - finds nothing of what Hermes applied and puts the
+     * headless output back on the catch-all rule: on a scaled desktop that
+     * means a different mode, a different scale and an auto position, while
+     * the stream keeps encoding the size it negotiated. A rule keyed by the
+     * output's name is what `hyprctl keyword monitor` adds by hand, and it is
+     * what the reload finds. Rules replace by name and HEADLESS-N names are
+     * not reused, so one stale rule per session name remains until the next
+     * config reload; it matches nothing once its output is gone.
+     *
+     * The rule goes through `eval hl.monitor({...})` first, the only form
+     * Hyprland main still registers, and through `keyword monitor` when eval
+     * is refused, for a release that still parses the legacy config.
+     *
+     * The position stays `auto`. Adding the rule makes Hyprland lay out every
+     * monitor again, and a physical monitor on an `auto` rule is then placed
+     * after any explicitly positioned one - pinning the position Hermes just
+     * applied would shove the physical monitor to the right of the virtual
+     * one. With `auto` on both, the virtual output lands after the physical
+     * ones, which is where the wlr-output-management step put it anyway. A
+     * future `mirror` layout on Hyprland belongs in this rule too, through
+     * Hyprland's `mirror` option, not in overlapping positions.
+     */
+    static void pin_output(const std::string &name, int width, int height, int refresh_mhz) {
+      if (width <= 0 || height <= 0) {
+        return;
+      }
+      // The name is interpolated into a Lua expression and a config line.
+      if (!safe_output_name(name)) {
+        BOOST_LOG(warning) << "[VDISPLAY] Refusing to pin a Hyprland monitor rule for an unsafe output name.";
+        return;
+      }
+      std::string mode = std::to_string(width) + "x" + std::to_string(height);
+      if (refresh_mhz > 0) {
+        char refresh[32];
+        std::snprintf(refresh, sizeof(refresh), "@%.3f", refresh_mhz / 1000.0);
+        mode += refresh;
+      }
+
+      std::string rule = "hl.monitor({ output = \"" + name + "\", mode = \"" + mode + "\", position = \"auto\", scale = 1 })";
+      auto reply = request("/eval " + rule);
+      if (!reply || reply->rfind("ok", 0) != 0) {
+        BOOST_LOG(info) << "[VDISPLAY] Hyprland did not take the monitor rule through eval"
+                        << (reply ? " (" + *reply + ")" : " (no reply from its socket)") << "; trying keyword.";
+        rule = name + "," + mode + ",auto,1";
+        reply = request("/keyword monitor " + rule);
+      }
+      if (!reply || reply->rfind("ok", 0) != 0) {
+        BOOST_LOG(warning) << "[VDISPLAY] Hyprland refused the monitor rule '" << rule << "'"
+                           << (reply ? ": " + *reply : " (no reply from its socket).");
+        return;
+      }
+      BOOST_LOG(info) << "[VDISPLAY] Pinned Hyprland monitor rule '" << rule << "'";
     }
 
     static bool remove_output(const std::string &name) {
@@ -6365,7 +6432,17 @@ namespace VDISPLAY {
       return mutter::apply_output_mode(connector, width, height, refresh_mhz, deadline_ms);
     }
 #ifdef SUNSHINE_BUILD_WAYLAND
-    return wl::configure_virtual_output(connector, width, height, refresh_mhz, false);
+    const bool applied = wl::configure_virtual_output(connector, width, height, refresh_mhz, false);
+    if (applied && !getHyprlandOutputName(displayName).empty()) {
+      if (virtual_display_layout(displayName) == virtual_display_layout_e::mirror) {
+        BOOST_LOG(warning) << "[VDISPLAY] The mirror layout is not implemented on Hyprland; "
+                              "the virtual output extends the desktop instead.";
+      }
+      // Pinned here rather than at creation so a mid-session mode change
+      // re-pins the new mode.
+      hyprland::pin_output(connector, width, height, refresh_mhz);
+    }
+    return applied;
 #else
     (void) connector;
     return false;

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -6,6 +6,8 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <climits>
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -45,6 +47,49 @@ using namespace std::literals;
 #pragma GCC diagnostic ignored "-Wpmf-conversions"
 
 namespace wl {
+  void logical_size(int mode_width, int mode_height, int transform, wl_fixed_t scale, int &width, int &height) {
+    const bool rotated = transform & 1;
+    width = rotated ? mode_height : mode_width;
+    height = rotated ? mode_width : mode_height;
+    // Fixed point is exact to 1/256, so two decimals recover any scale a user
+    // is likely to have configured without changing an exact one.
+    const double factor = std::round(wl_fixed_to_double(scale) * 100.0) / 100.0;
+    if (factor > 0.0) {
+      width = (int) std::lround(width / factor);
+      height = (int) std::lround(height / factor);
+    }
+  }
+
+  output_rect_t desktop_envelope(const std::vector<output_rect_t> &outputs) {
+    int left = INT_MAX;
+    int top = INT_MAX;
+    int right = INT_MIN;
+    int bottom = INT_MIN;
+    for (const auto &output : outputs) {
+      if (output.width <= 0 || output.height <= 0) {
+        continue;
+      }
+      left = std::min(left, output.x);
+      top = std::min(top, output.y);
+      right = std::max(right, output.x + output.width);
+      bottom = std::max(bottom, output.y + output.height);
+    }
+    if (left == INT_MAX) {
+      return {0, 0, 0, 0};
+    }
+    return {left, top, right - left, bottom - top};
+  }
+
+  input_geometry_t input_geometry(const output_rect_t &envelope, const output_rect_t &output, int mode_width, int mode_height) {
+    const double s_x = output.width > 0 && mode_width > 0 ? (double) mode_width / output.width : 1.0;
+    const double s_y = output.height > 0 && mode_height > 0 ? (double) mode_height / output.height : 1.0;
+    return {
+      (int) std::lround((output.x - envelope.x) * s_x),
+      (int) std::lround((output.y - envelope.y) * s_y),
+      (int) std::lround(envelope.width * s_x),
+      (int) std::lround(envelope.height * s_y),
+    };
+  }
 
   // Helper to call C++ method from wayland C callback
   template<class T, class Method, Method m, class... Params>
@@ -379,8 +424,14 @@ namespace wl {
       bool valid = true;
       int right_edge = 0;
       for (const auto &head : control.heads) {
-        if (head->enabled && head->current_mode) {
-          right_edge = std::max(right_edge, head->x + head->current_mode->width);
+        if (head->enabled && head->current_mode && head.get() != &virtual_head) {
+          // Positions are logical, so the edge has to be logical too. Adding
+          // the mode width instead leaves a gap after a scaled output, which
+          // the cursor cannot cross.
+          int logical_width = 0;
+          int logical_height = 0;
+          logical_size(head->current_mode->width, head->current_mode->height, head->transform, head->scale, logical_width, logical_height);
+          right_edge = std::max(right_edge, head->x + logical_width);
         }
       }
 
@@ -490,6 +541,9 @@ namespace wl {
   }
 
   void monitor_t::xdg_size(zxdg_output_v1 *, std::int32_t width, std::int32_t height) {
+    logical_width = width;
+    logical_height = height;
+
     BOOST_LOG(info) << "Logical size: "sv << width << 'x' << height;
   }
 

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -190,6 +190,9 @@ namespace wl {
     std::string name;
     std::string description;
     platf::touch_port_t viewport;
+    // Size in the compositor's logical coordinates (xdg_output); 0 until known.
+    int logical_width {0};
+    int logical_height {0};
     wl_output_listener wl_listener;
     zxdg_output_v1_listener xdg_listener;
   };
@@ -267,6 +270,58 @@ namespace wl {
   };
 
   std::vector<std::unique_ptr<monitor_t>> monitors(const char *display_name = nullptr);
+
+  /**
+   * @brief Size of a head in the compositor's logical coordinates, the wlr
+   * counterpart of mutter::state_t::logical_size.
+   *
+   * Head positions are logical, so anything added to them has to be logical
+   * too: the mode's pixel size divided by the scale, with the axes swapped for
+   * a rotated transform. `transform & 1` covers the 90 and 270 degree
+   * rotations including their flipped variants (WL_OUTPUT_TRANSFORM_FLIPPED_90
+   * is 5 and _FLIPPED_270 is 7). The scale arrives as 24.8 fixed point and is
+   * rounded to two decimals first: 1.6 is carried as 410/256 = 1.6015625, and
+   * 3840 divided by that rounds to 2398 where the compositor lays out 2400.
+   * @param scale The head's scale as wl_fixed_t; a non-positive scale counts as 1.
+   */
+  void logical_size(int mode_width, int mode_height, int transform, wl_fixed_t scale, int &width, int &height);
+
+  /** An output's rectangle in the compositor's logical coordinates. */
+  struct output_rect_t {
+    int x, y;
+    int width, height;
+  };
+
+  /**
+   * @brief The desktop envelope: the bounding box of every output in logical
+   * coordinates, origin included. wlroots-style compositors (Hyprland, sway)
+   * spread an absolute input device across exactly this box.
+   *
+   * Outputs without a positive size are skipped; with none left the envelope
+   * is all zeros.
+   */
+  output_rect_t desktop_envelope(const std::vector<output_rect_t> &outputs);
+
+  /** The streamed output's place in the desktop envelope, see platf::display_t. */
+  struct input_geometry_t {
+    int offset_x, offset_y;
+    int env_width, env_height;
+  };
+
+  /**
+   * @brief Express an output's offset within the envelope, and the envelope,
+   * in that output's own capture pixels.
+   *
+   * platf::display_t carries both that way, and the consumer forms
+   * (offset + x) / env, so scaling the logical values by mode / logical size
+   * gives the same ratio as converting x into logical space would. An output
+   * whose logical size is unknown (zero) counts as scale 1.
+   * @param output The streamed output's logical rectangle.
+   * @param mode_width The streamed output's mode, i.e. capture, width.
+   * @param mode_height The streamed output's mode, i.e. capture, height.
+   */
+  input_geometry_t input_geometry(const output_rect_t &envelope, const output_rect_t &output, int mode_width, int mode_height);
+
   /**
    * Configure a virtual output through wlroots' output-management protocol.
    * Returns false when the compositor does not expose that protocol or rejects

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -20,8 +20,25 @@
 using namespace std::literals;
 
 namespace wl {
-  static int env_width;
-  static int env_height;
+  /**
+   * @brief Every monitor's rectangle in the compositor's logical coordinates,
+   * for wl::desktop_envelope().
+   *
+   * xdg_output reports position and size in logical pixels. A monitor whose
+   * logical size never arrived is taken at scale 1, so its mode size stands
+   * in for the logical one.
+   */
+  static std::vector<output_rect_t> output_rects(const std::vector<std::unique_ptr<monitor_t>> &monitors) {
+    std::vector<output_rect_t> rects;
+    rects.reserve(monitors.size());
+    for (const auto &monitor : monitors) {
+      const auto &viewport = monitor->viewport;
+      const int width = monitor->logical_width > 0 ? monitor->logical_width : viewport.width;
+      const int height = monitor->logical_height > 0 ? monitor->logical_height : viewport.height;
+      rects.push_back({viewport.offset_x, viewport.offset_y, width, height});
+    }
+    return rects;
+  }
 
   struct img_t: public platf::img_t {
     ~img_t() override {
@@ -151,13 +168,27 @@ namespace wl {
       width = monitor->viewport.width;
       height = monitor->viewport.height;
 
-      this->env_width = ::wl::env_width;
-      this->env_height = ::wl::env_height;
+      // The compositor spreads an absolute input device across the logical
+      // bounding box of every output, origin included. The box comes from
+      // this connection's monitor list rather than from a snapshot taken when
+      // displays were enumerated, since the layout may have changed since.
+      // Both the offset within it and its size are then expressed in this
+      // output's own capture pixels, which is how platf::display_t carries
+      // them on every capture path.
+      const auto envelope = desktop_envelope(output_rects(interface.monitors));
+      const output_rect_t streamed {offset_x, offset_y, monitor->logical_width, monitor->logical_height};
+      const auto geometry = input_geometry(envelope, streamed, width, height);
+      offset_x = geometry.offset_x;
+      offset_y = geometry.offset_y;
+      env_width = geometry.env_width;
+      env_height = geometry.env_height;
 
       BOOST_LOG(info) << "Selected monitor ["sv << monitor->description << "] for streaming"sv;
-      BOOST_LOG(debug) << "Offset: "sv << offset_x << 'x' << offset_y;
       BOOST_LOG(debug) << "Resolution: "sv << width << 'x' << height;
-      BOOST_LOG(debug) << "Desktop Resolution: "sv << env_width << 'x' << env_height;
+      BOOST_LOG(info) << "Desktop envelope "sv << envelope.width << 'x' << envelope.height << " at "sv << envelope.x << ',' << envelope.y
+                      << " (logical), streamed output "sv << streamed.width << 'x' << streamed.height << " at "sv << streamed.x << ',' << streamed.y
+                      << "; in its "sv << width << 'x' << height << " pixels: envelope "sv << env_width << 'x' << env_height
+                      << ", offset "sv << offset_x << ',' << offset_y;
 
       return 0;
     }
@@ -548,9 +579,6 @@ namespace platf {
       return {};
     }
 
-    wl::env_width = 0;
-    wl::env_height = 0;
-
     for (auto &monitor : interface.monitors) {
       monitor->listen(interface.output_manager);
     }
@@ -562,13 +590,13 @@ namespace platf {
     for (int x = 0; x < interface.monitors.size(); ++x) {
       auto monitor = interface.monitors[x].get();
 
-      wl::env_width = std::max(wl::env_width, (int) (monitor->viewport.offset_x + monitor->viewport.width));
-      wl::env_height = std::max(wl::env_height, (int) (monitor->viewport.offset_y + monitor->viewport.height));
-
       BOOST_LOG(info) << "Monitor " << x << " is "sv << monitor->name << ": "sv << monitor->description;
 
       display_names.emplace_back(std::to_string(x));
     }
+
+    const auto envelope = wl::desktop_envelope(wl::output_rects(interface.monitors));
+    BOOST_LOG(debug) << "Desktop envelope: "sv << envelope.width << 'x' << envelope.height << " at "sv << envelope.x << ',' << envelope.y << " (logical)"sv;
 
     BOOST_LOG(info) << "--------- End of Wayland monitor list ---------"sv;
 

--- a/tests/unit/platform/test_wayland_layout.cpp
+++ b/tests/unit/platform/test_wayland_layout.cpp
@@ -1,0 +1,78 @@
+/**
+ * @file tests/unit/platform/test_wayland_layout.cpp
+ * @brief Test the logical layout arithmetic in src/platform/linux/wayland.cpp.
+ *
+ * No compositor is needed: these check the numbers the capture path derives
+ * from what wlr-output-management and xdg_output report, which is where a
+ * scaled or rotated output used to be counted in mode pixels.
+ */
+#include "../../tests_common.h"
+
+#ifdef SUNSHINE_BUILD_WAYLAND
+
+  #include <src/platform/linux/wayland.h>
+
+TEST(WaylandLogicalSize, DividesTheModeByARoundedScale) {
+  int width = 0;
+  int height = 0;
+  // 1.6 arrives as 410/256 = 1.6015625; unrounded, 3840 / that is 2398.
+  wl::logical_size(3840, 2160, WL_OUTPUT_TRANSFORM_NORMAL, 410, width, height);
+  EXPECT_EQ(width, 2400);
+  EXPECT_EQ(height, 1350);
+}
+
+TEST(WaylandLogicalSize, SwapsTheAxesOfARotatedHead) {
+  int width = 0;
+  int height = 0;
+  wl::logical_size(3840, 2160, WL_OUTPUT_TRANSFORM_90, wl_fixed_from_int(1), width, height);
+  EXPECT_EQ(width, 2160);
+  EXPECT_EQ(height, 3840);
+
+  wl::logical_size(3840, 2160, WL_OUTPUT_TRANSFORM_FLIPPED_90, wl_fixed_from_int(1), width, height);
+  EXPECT_EQ(width, 2160);
+  EXPECT_EQ(height, 3840);
+}
+
+TEST(WaylandDesktopEnvelope, IncludesANegativeOrigin) {
+  const auto envelope = wl::desktop_envelope({{-2400, 0, 2400, 1350}, {0, 0, 1920, 1080}});
+  EXPECT_EQ(envelope.x, -2400);
+  EXPECT_EQ(envelope.y, 0);
+  EXPECT_EQ(envelope.width, 4320);
+  EXPECT_EQ(envelope.height, 1350);
+}
+
+TEST(WaylandDesktopEnvelope, UsesTheLogicalSizeNotTheMode) {
+  // A 3840x2160 monitor at scale 1.6 is 2400x1350 logical, so a 1920x1080
+  // output beside it sits at 2400 and the envelope is 4320 wide, not 5760.
+  int width = 0;
+  int height = 0;
+  wl::logical_size(3840, 2160, WL_OUTPUT_TRANSFORM_NORMAL, 410, width, height);
+  const auto envelope = wl::desktop_envelope({{0, 0, width, height}, {2400, 0, 1920, 1080}});
+  EXPECT_EQ(envelope.x, 0);
+  EXPECT_EQ(envelope.y, 0);
+  EXPECT_EQ(envelope.width, 4320);
+  EXPECT_EQ(envelope.height, 1350);
+}
+
+TEST(WaylandInputGeometry, ScalesTheEnvelopeIntoTheStreamedOutputsPixels) {
+  // A 1920x1080 monitor at scale 1 on the left, and the streamed 3840x2160
+  // monitor at scale 1.6 (2400x1350 logical) at 1920,0: the envelope is
+  // 4320x1350 logical, which is 6912x2160 in the streamed output's pixels,
+  // and the offset 1920 becomes 3072.
+  const auto envelope = wl::desktop_envelope({{0, 0, 1920, 1080}, {1920, 0, 2400, 1350}});
+  const auto geometry = wl::input_geometry(envelope, {1920, 0, 2400, 1350}, 3840, 2160);
+  EXPECT_EQ(geometry.offset_x, 3072);
+  EXPECT_EQ(geometry.offset_y, 0);
+  EXPECT_EQ(geometry.env_width, 6912);
+  EXPECT_EQ(geometry.env_height, 2160);
+}
+
+TEST(WaylandInputGeometry, TakesAnUnknownLogicalSizeAsScaleOne) {
+  const auto geometry = wl::input_geometry({0, 0, 3840, 1080}, {1920, 0, 0, 0}, 1920, 1080);
+  EXPECT_EQ(geometry.offset_x, 1920);
+  EXPECT_EQ(geometry.offset_y, 0);
+  EXPECT_EQ(geometry.env_width, 3840);
+  EXPECT_EQ(geometry.env_height, 1080);
+}
+
+#endif  // SUNSHINE_BUILD_WAYLAND


### PR DESCRIPTION

Fixes #35.

## Problem

Absolute mouse positions on the wlroots capture path were normalised against
a desktop envelope built from each output's logical (xdg_output) position
plus its physical mode size, computed once when the outputs were enumerated
and assumed to start at 0,0. Hyprland and other wlroots-style compositors
spread an absolute pointer device across the bounding box of all outputs in
logical (scaled) pixels (`CPointerManager::warpAbsolute` in Hyprland's
`src/pointer/PointerManager.cpp`). The two agree only when every output is at
scale 1 and the layout starts at the origin, so on a scaled desktop with a
physical monitor and a virtual display both active the cursor reached a
different area of the streamed output than the client pointed at, and a
headless output created for the session was never in the envelope at all.
With the virtual display as the only output the scale cancels out, which is
why turning the physical monitor off made the bug disappear. Details and
measurements are in #35.

4973c7da fixed the same class of problem for GNOME by reading Mutter's
logical monitor layout; this does the equivalent for the wlroots capture
path, where xdg_output already reports the logical size, and hands the
result on in the same representation.

## Changes

- **Envelope in logical space, handed on in the output's pixels.**
  `wlr_t::init()` in `wlgrab.cpp` builds the envelope as the logical
  bounding box of every output, origin included, from the capture
  connection's own monitor list (`wl::desktop_envelope()`), and stores the
  streamed output's offset within it and the envelope size scaled by the
  output's mode-to-logical ratio in the existing
  `display_t::offset_x/offset_y/env_width/env_height`
  (`wl::input_geometry()`). The consumer forms `(offset + x) / envelope`, so
  this is the same ratio as converting `x` into logical space, and
  `input.cpp`, `input.h` and `video.cpp` are untouched. Touch and pen read the
  same four fields and therefore get the same mapping as the mouse.
  `common.h` gains a two-line comment stating that contract, which the
  KScreen, Mutter and now wlroots paths all follow. The result is logged
  once at info, for example
  `Desktop envelope 4320x1350 at 0,0 (logical), streamed output 1920x1080 at 2400,0; in its 1920x1080 pixels: envelope 4320x1350, offset 2400,0`.
- **Logical right edge for the virtual output.** `wayland.cpp`
  `apply_configuration()` places the virtual head at
  `x + wl::logical_size(...)` of the other enabled heads instead of
  `x + mode width`, which left a gap after a scaled output (the 1920 px gap
  at x 4320 in #35 that the host's own cursor could not cross). The 24.8
  fixed-point scale is rounded to two decimals first: 1.6 arrives as
  `410/256 = 1.6015625`, which put the edge at 2398 instead of 2400, and
  Hyprland reported the overlap.
- **A Hyprland monitor rule pins the headless output.** Hyprland applies
  wlr-output-management state on top of the matching monitor rule, but that
  state lives in the requesting client's manager object and is erased when
  the client disconnects; `configure_virtual_output()` destroys its
  connection on return, so the next rule reload (a physical display
  powering off is enough) put the headless output back on the catch-all
  rule mid-stream. `hyprland::pin_output()` in `virtual_display.cpp` sends
  `eval hl.monitor({ output = ..., mode = ..., position = "auto", scale = 1 })`
  first (the only form Hyprland `main` still registers) and falls back to
  `keyword monitor` for a release on the legacy config. It runs from
  `pushVirtualOutputMode()` so a mid-session mode change re-pins, the
  output name is checked with `safe_output_name()` before it is
  interpolated, and the position stays `auto` because an explicit one would
  push an `auto`-placed physical monitor after the virtual one. A `mirror`
  layout is logged as not implemented on Hyprland; when it is, it belongs
  in this rule.
- **Pure layout helpers and tests.** `wl::logical_size()` (the wlr
  counterpart of `mutter::state_t::logical_size`, transform-aware),
  `wl::desktop_envelope()` and `wl::input_geometry()` are declared in
  `wayland.h`; `tests/unit/platform/test_wayland_layout.cpp` covers the
  rounded scale (3840 at 1.6015625 gives 2400), rotated heads, a negative
  origin, logical size over mode, the output-pixel conversion, and an
  unknown logical size treated as scale 1.
- `CHANGELOG.md` under Unreleased, and Known limitations in
  `docs/compatibility.md`.

## Testing

Manual, on Arch Linux (Omarchy) with Hyprland 0.56.2 configured in Lua, a
Dell U2720Q at 3840x2160 scale 1.6 (logical 2400x1350) and a 1920x1080
Hermes virtual display, Hestia v0.1.0 over LAN in absolute mouse mode.

- Cursor positions measured with a uinput absolute device set up like
  inputtino's, in logical pixels on the virtual display; the numbers and
  the layout they were taken in are in #35. Before: the client's
  bottom-right corner landed past the output's edge and its centre off
  centre; after: on the edge and 1 px from the centre.
- Without the change (the attached log on #35): the virtual display comes
  up at x 4320 next to the 2400-wide monitor, the client's mouse does not
  move the cursor at all while the keyboard works, and the host's own mouse
  can reach every corner of the virtual display but cannot get back to the
  physical monitor.
- With this branch installed and the physical monitor on: the log reports
  the envelope line quoted above and
  `Pinned Hyprland monitor rule 'hl.monitor({ output = "HEADLESS-302", mode = "1920x1080@60.000", position = "auto", scale = 1 })'`,
  the headless output sits at 2400,0, the client's cursor covers the whole
  streamed screen and stays on it in every corner, the host's mouse moves
  back to the physical monitor, and Hyprland shows no overlap warning. I
  have been using this build for day-to-day remote sessions since
  2026-09-02.
- Unit tests, run inside the Hyprland session:
  `--gtest_filter='Wayland*'` 11 passed, 1 skipped, 1 failed; full suite
  281 passed, 6 skipped, 1 failed, from the test binary built at bc0671e99.
  The failure is `ScreencopyStillProducesAFrame` in the unchanged
  `test_wayland_capture.cpp`, which hits the multi-GPU screencopy
  allocation problem on this host (#34) and fails the same way on `main`
  here; with #34's branch it passes.
  Builds clean with LTO; `git clang-format --diff` reports nothing.

The streamed build was on de5126f7. The branch was then rebased onto
8508186bc, which also changes `virtual_display.cpp`; the rebase applied
there without conflict (only `CHANGELOG.md` conflicted), the changed lines
are byte-identical to what was streamed, and the rebased tree compiles;
the unit-test numbers above are from the rebased commit. The rebased build
has not been streamed.

Not tested: a Hyprland with a legacy (non-Lua) config, so the `keyword`
fallback was never reached here; rotated outputs on hardware (the axis
swap is unit-tested only); touch and pen on this desktop (the mapping is
shared with the mouse but was not driven by hand); sway and other wlroots
compositors, which take the envelope change but have no rule pin.

Written with Claude Code, as I said on #35. What I can stand behind is the
testing above, done by hand on the host described.

## Known limitations

- KMS capture of a physical monitor at a scale other than 1 has the same
  mismatch and is not changed here.
- One monitor rule per session name stays in Hyprland until the next config
  reload (HEADLESS-N names are not reused, so it matches nothing once the
  output is gone), and a config reload discards it; the next session pins
  again. Keeping the wlr-output-management connection open for the session
  would avoid the rule on every compositor, at the cost of servicing that
  connection for the session's lifetime; noted as a possible follow-up.
- The virtual output is placed at an explicit position computed at that
  moment; an output another tool creates in the same instant can land on
  the same spot and draw Hyprland's overlap warning until the next
  re-arrangement (seen once, with a screenshot harness creating its own
  headless output during session start).
- This branch merges on its own. #34's branch touches `CHANGELOG.md`,
  `docs/compatibility.md` and the declarations block of `wayland.h` too,
  so whichever lands second needs a rebase that keeps both sides; no code
  lines overlap. The resolved merge of all three PRs on 8508186bc is
  https://github.com/danielbaldwin47/Hermes/tree/main-plus-fixes, which is
  what I run.