### PR TITLE
fix(vdisplay): advertise only selectable virtual display backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -644,6 +644,11 @@ run `scripts/bump-version.sh <major|minor|patch>` — it moves everything under
   while a session is live, since Hermes holds those ports itself then and every
   one of them would read as taken.
 
+- The Hestia capabilities document advertises only the virtual display backends
+  a client can be served by (`evdi`, `hermes_kms`), which is also what
+  `capabilities.schema.json` allows. Advertising `none` made every shipped
+  Hestia reject the whole document and launch without asking for a virtual
+  display, so the physical monitor was mirrored instead ([#36], [#25]).
 - Absolute pointer input now lands on the streamed display under GNOME. Mutter
   measures an absolute pointing device against the extents of the whole stage,
   so a client's coordinates only arrive on the right monitor once they carry
@@ -1255,6 +1260,7 @@ run `scripts/bump-version.sh <major|minor|patch>` — it moves everything under
 [#25]: https://github.com/MrOz59/Hermes/issues/25
 [#28]: https://github.com/MrOz59/Hermes/issues/28
 [#29]: https://github.com/MrOz59/Hermes/issues/29
+[#36]: https://github.com/MrOz59/Hermes/issues/36
 
 ## [0.4.0] - 2026-07-02
 

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -1495,7 +1495,7 @@ namespace confighttp {
       }},
       {"features", {
         {"virtual_display", true},
-        {"virtual_display_backend", {"evdi", "hermes_kms", "none"}},
+        {"virtual_display_backend", {"evdi", "hermes_kms"}},
         {"hermes_kms_multi_output", {
           {"supported", true},
           {"experimental", true},


### PR DESCRIPTION

Fixes #36. Related: #25.

## Problem

f67bc8d9 added "none" to the `virtual_display_backend` list in the Hestia
capabilities document. Hestia v0.1.0 validates that list against a closed
set of `evdi` and `hermes_kms`, the same enum as `capabilities.schema.json`
in this repository; an unknown value fails the whole document, the client
falls back to plain Moonlight behaviour and never posts the session prepare
request, which is the only channel through which Hestia asks for a virtual
display (it does not add `virtualDisplay=1` to `/launch` the way Artemis
does). The host then logs `Virtual display not requested for this session`
and mirrors the physical monitor: the symptom of #25, with a different
cause that only exists on `main`. Details in #36.

## Change

One line in `src/confighttp.cpp`: the advertised list is back to `evdi` and
`hermes_kms`, which is what `capabilities.schema.json` allows. "none" is
the absence of a driver, not a driver a client can be served by; it stays a
valid `virtual_display_backend` value in `hermes.conf`, and the prepare
request still accepts it as the client's own choice. `CHANGELOG.md` gets an
entry under Unreleased / Fixed.

Possible follow-up, not bundled here: on a host configured with
`virtual_display_backend = none` the document still says
`"virtual_display": true`, so Hestia asks and the request is downgraded to
none in `virtual_display.cpp` (`selected_backend()`); reporting `false`
there would let the client know up front.

## Testing

Manual, Hestia v0.1.0 client with "use virtual display" enabled, host debug
logging on, both logs attached to #36.

- Without the change (host at 4973c7da plus the #34 fix, list still
  advertising "none"): `GET /api/hestia/v1/capabilities`, then `GET /launch`
  with no prepare POST in between; the host logs
  `Virtual display not requested for this session` and the physical monitor
  is mirrored.
- With the change (the same host, one commit later on de5126f7, plus this
  line and the #35 fix):
  the client posts `/api/hestia/v1/session/prepare`, the host logs
  `[HestiaAPI] applying prepared session ... virtual_display=true`, and a
  headless output is created for the session. Nothing changed on the client
  between the two runs.
- No test exercises the capabilities document (`tests/unit/test_confighttp.cpp`
  covers the preflight document and the game-mode token origin check), so
  the unit test suite is unchanged by this.

The streamed build was on de5126f7; the branch is rebased onto 8508186bc,
where the line is unchanged, and compiles there. `CHANGELOG.md` conflicts
with #34 and #35 (adjacent entries under Unreleased); trivial to keep all
three.

Written with Claude Code, as I said on #36. What I can stand behind is the
testing above, done by hand on the host described.